### PR TITLE
Suppress warnings from skopt using deprecated sklearn API

### DIFF
--- a/deephyper/__init__.py
+++ b/deephyper/__init__.py
@@ -20,6 +20,7 @@ DeepHyper installation requires **Python 3.6**.
 
 """
 import os
+import warnings
 from deephyper.__version__ import __version__, __version_suffix__
 name = 'deephyper'
 version = __version__
@@ -27,3 +28,9 @@ version = __version__
 # ! Check if a balsam db is connected or not
 if os.environ.get("BALSAM_DB_PATH") is None:
     os.environ["BALSAM_SPHINX_DOC_BUILD_ONLY"] = "TRUE"
+
+# Suppress warnings from skopt using deprecated sklearn API
+warnings.filterwarnings('ignore', category=FutureWarning,
+                        message='sklearn.externals.joblib is deprecated')
+warnings.filterwarnings('ignore', category=FutureWarning,
+                        message='the sklearn.metrics.scorer module')


### PR DESCRIPTION
Closes #12. The warning is due to https://github.com/scikit-optimize/scikit-optimize still using the deprecated `sklearn` API as of `skopt` v0.5.2 (2018-03-25). 

Discussed in https://github.com/scikit-optimize/scikit-optimize/issues/774

They have two open PRs that address this, but they haven't been updated in months:
- https://github.com/scikit-optimize/scikit-optimize/pull/776
- https://github.com/scikit-optimize/scikit-optimize/pull/777