### PR TITLE
Workaround for OpenSSL incompatibility with Ray dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ REQUIRED = [
     'joblib>=0.10.3',
     'pydot',
     'balsam-flow==0.3.8',
-    'ray==0.7.2',
+    'ray>=0.7.6',
     'Jinja2'
 ]
 


### PR DESCRIPTION
Bump minimum version of https://github.com/ray-project/ray dependency so that users get a wheel built with OpenSSL 1.1.1. 