### PR TITLE
Fix coupling to Balsam

### DIFF
--- a/deephyper/core/plot/stub/hps_analytics.ipynb
+++ b/deephyper/core/plot/stub/hps_analytics.ipynb
@@ -96,12 +96,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.plot(df.elapsed_sec, df.objective)\n",
-    "plt.ylabel('Objective')\n",
-    "plt.xlabel('Time (s.)')\n",
-    "plt.xlim(0)\n",
-    "plt.grid()\n",
-    "plt.show()"
+    "fig = plt.figure()\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(df.elapsed_sec, df.objective)\n",
+    "ax.set_ylabel('Objective')\n",
+    "ax.set_xlabel('Time (s.)')\n",
+    "ax.set_xlim(0)\n",
+    "ax.grid()\n",
+    "fig.show()"
    ]
   },
   {
@@ -131,8 +133,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fig = plt.figure()\n",
+    "fig, ax = plt.subplots()\n",
     "corr = df.loc[:, filter(lambda n: n not in not_include, df.columns)].corr()\n",
-    "sns.heatmap(corr, xticklabels=corr.columns, yticklabels=corr.columns, cmap=sns.diverging_palette(220, 10, as_cmap=True))\n",
+    "sns.heatmap(corr, xticklabels=corr.columns, yticklabels=corr.columns, cmap=sns.diverging_palette(220, 10, as_cmap=True), ax=ax)\n",
+    "ax.set_yticklabels(corr.columns, va='center')\n",
     "plt.show()"
    ]
   },

--- a/deephyper/evaluator/_balsam.py
+++ b/deephyper/evaluator/_balsam.py
@@ -1,7 +1,5 @@
-import json
 import logging
 import os
-from io import StringIO
 
 from balsam.core.models import ApplicationDefinition as AppDef
 from balsam.launcher import dag
@@ -15,7 +13,7 @@ from django.db import transaction
 logger = logging.getLogger(__name__)
 
 LAUNCHER_NODES = int(os.environ.get('BALSAM_LAUNCHER_NODES', 1))
-JOB_MODE = int(os.environ.get('BALSAM_JOB_MODE', 1))
+JOB_MODE = os.environ.get('BALSAM_JOB_MODE', 'mpi')
 
 
 class BalsamEvaluator(Evaluator):

--- a/deephyper/evaluator/_balsam.py
+++ b/deephyper/evaluator/_balsam.py
@@ -15,23 +15,40 @@ from django.db import transaction
 logger = logging.getLogger(__name__)
 
 LAUNCHER_NODES = int(os.environ.get('BALSAM_LAUNCHER_NODES', 1))
+JOB_MODE = int(os.environ.get('BALSAM_JOB_MODE', 1))
 
 
 class BalsamEvaluator(Evaluator):
-    """Evaluator using balsam software.
+    """Evaluator using Balsam software.
 
-    Documentation to balsam : https://balsam.readthedocs.io
+    Documentation to Balsam : https://balsam.readthedocs.io
     This class helps us to run task on HPC systems with more flexibility and ease of use.
 
     Args:
         run_function (func): takes one parameter of type dict and returns a scalar value.
-        cache_key (func): takes one parameter of type dict and returns a hashable type, used as the key for caching evaluations. Multiple inputs that map to the same hashable key will only be evaluated once. If ``None``, then cache_key defaults to a lossless (identity) encoding of the input dict.
+        cache_key (func): takes one parameter of type dict and returns a hashable type,
+            used as the key for caching evaluations. Multiple inputs that map to the same
+            hashable key will only be evaluated once. If ``None``, then cache_key defaults
+            to a lossless (identity) encoding of the input dict.
     """
 
     def __init__(self, run_function, cache_key=None, **kwargs):
         super().__init__(run_function, cache_key)
         self.id_key_map = {}
-        self.num_workers = max(1, LAUNCHER_NODES*self.WORKERS_PER_NODE - 2)
+        # reserve 1 DeepHyper worker for learner/search process
+        if LAUNCHER_NODES == 1:
+            # --job-mode=serial edge case where 2 ranks (Master, Worker) are placed on the node
+            self.num_workers = self.WORKERS_PER_NODE - 1
+            # 1 node case for --job-mode=mpi will result in search process occupying
+            # entirety of the only node ---> no evaluator workers (also should have DEEPHYPER_WORKERS_PER_NODE=1)
+        else:
+            if JOB_MODE == 'serial':
+                # MPI ensemble Master rank0 occupies entirety of first node
+                self.num_workers = (LAUNCHER_NODES - 1) * self.WORKERS_PER_NODE - 1
+            if JOB_MODE == 'mpi':
+                # all nodes free, but restricted to 1 job=worker per node
+                assert self.WORKERS_PER_NODE == 1
+                self.num_workers = LAUNCHER_NODES * self.WORKERS_PER_NODE - 1
         logger.info("Balsam Evaluator instantiated")
         logger.debug(f"LAUNCHER_NODES = {LAUNCHER_NODES}")
         logger.debug(f"WORKERS_PER_NODE = {self.WORKERS_PER_NODE}")
@@ -63,7 +80,7 @@ class BalsamEvaluator(Evaluator):
         jobname = f"task{self.counter}"
         args = f"'{self.encode(x)}'"
         envs = f"KERAS_BACKEND={self.KERAS_BACKEND}"
-        #envs = ":".join(f'KERAS_BACKEND={self.KERAS_BACKEND} OMP_NUM_THREADS=62 KMP_BLOCKTIME=0 KMP_AFFINITY=\"granularity=fine,compact,1,0\"'.split())
+        # envs = ":".join(f'KERAS_BACKEND={self.KERAS_BACKEND} OMP_NUM_THREADS=62 KMP_BLOCKTIME=0 KMP_AFFINITY=\"granularity=fine,compact,1,0\"'.split())
         resources = {
             'num_nodes': 1,
             'ranks_per_node': 1,
@@ -97,17 +114,17 @@ class BalsamEvaluator(Evaluator):
     def _on_done(job):  # def _on_done(job, process_data):
         output = job.read_file_in_workdir(f'{job.name}.out')
         # process_data(job)
-        #args = job.args
-        #args = args.replace("\'", "")
+        # args = job.args
+        # args = args.replace("\'", "")
         # with open('test.json', 'w') as f:
         #    f.write(args)
         #
         # with open('test.json', 'r') as f:
         #    args = json.load(f)
         output = Evaluator._parse(output)
-        #job.data['reward'] = output
-        #job.data['arch_seq'] = args['arch_seq']
-        #job.data['id_worker'] = args['w']
+        # job.data['reward'] = output
+        # job.data['arch_seq'] = args['arch_seq']
+        # job.data['id_worker'] = args['w']
         # job.save()
         return output
 

--- a/deephyper/evaluator/_balsam.py
+++ b/deephyper/evaluator/_balsam.py
@@ -12,6 +12,7 @@ from django.db import transaction
 
 logger = logging.getLogger(__name__)
 
+# TODO(#30): "workers": should searcher be treated equivalently to evaluators?
 LAUNCHER_NODES = int(os.environ.get('BALSAM_LAUNCHER_NODES', 1))
 JOB_MODE = os.environ.get('BALSAM_JOB_MODE', 'mpi')
 
@@ -33,7 +34,7 @@ class BalsamEvaluator(Evaluator):
     def __init__(self, run_function, cache_key=None, **kwargs):
         super().__init__(run_function, cache_key)
         self.id_key_map = {}
-        # reserve 1 DeepHyper worker for learner/search process
+        # reserve 1 DeepHyper worker for searcher process
         if LAUNCHER_NODES == 1:
             # --job-mode=serial edge case where 2 ranks (Master, Worker) are placed on the node
             self.num_workers = self.WORKERS_PER_NODE - 1

--- a/deephyper/evaluator/evaluate.py
+++ b/deephyper/evaluator/evaluate.py
@@ -50,6 +50,9 @@ class Evaluator:
     """
     FAIL_RETURN_VALUE = -sys.float_info.max
     PYTHON_EXE = os.environ.get('DEEPHYPER_PYTHON_BACKEND', sys.executable)
+    # TODO(#30): DH CLI should handle this kind of dependent parameter.
+    # What if searcher process has surrogate model with --n-jobs>1? May need to reserve
+    # more than 1x DH "worker", if it is more expensive than a "evaluator". See _balsam.py
     WORKERS_PER_NODE = int(os.environ.get('DEEPHYPER_WORKERS_PER_NODE', 1))
     KERAS_BACKEND = os.environ.get('KERAS_BACKEND', 'tensorflow')
     os.environ['KERAS_BACKEND'] = KERAS_BACKEND
@@ -57,7 +60,7 @@ class Evaluator:
 
 
     def __init__(self, run_function, cache_key=None, encoder=Encoder,
-        seed=None, **kwargs):
+                 seed=None, **kwargs):
         self.encoder = encoder # dict --> uuid
         self.pending_evals = {}  # uid --> Future
         self.finished_evals = OrderedDict()  # uid --> scalar

--- a/deephyper/search/hps/ambs.py
+++ b/deephyper/search/hps/ambs.py
@@ -2,7 +2,7 @@
 
 Arguments of AMBS:
 
-* ``learner``
+* ``surrogate-model``
 
     * ``RF`` : Random Forest (default)
     * ``ET`` : Extra Trees
@@ -51,10 +51,10 @@ class AMBS(Search):
 
     @staticmethod
     def _extend_parser(parser):
-        parser.add_argument("--learner",
+        parser.add_argument("--surrogate-model",
                             default="RF",
                             choices=["RF", "ET", "GBRT", "DUMMY", "GP"],
-                            help='type of learner (surrogate model)'
+                            help='type of surrogate model (learner)'
                             )
         parser.add_argument('--liar-strategy',
                             default="cl_max",
@@ -69,7 +69,8 @@ class AMBS(Search):
         parser.add_argument('--acq-kappa', type=float, default=1.96,
                             help='Controls how much of the variance in the predicted values should be taken into account. If set to be very high, then we are favouring exploration over exploitation and vice versa. Used when the acquisition is "LCB".')
         parser.add_argument('--n-jobs', type=int, default=1,
-                            help="number of cores to use for the 'learner', if n_jobs=-1 then it will use all cores available.")
+                            # TODO(KGF): slightly inconsistent with nas/ambs.py (cores vs. parallel jobs)
+                            help="number of cores to use for the 'surrogate model' (learner), if n_jobs=-1 then it will use all cores available.")
         return parser
 
     def main(self):

--- a/deephyper/search/hps/optimizer/optimizer.py
+++ b/deephyper/search/hps/optimizer/optimizer.py
@@ -1,6 +1,7 @@
 from sys import float_info
 from skopt import Optimizer as SkOptimizer
-from skopt.learning import RandomForestRegressor, ExtraTreesRegressor, GradientBoostingQuantileRegressor
+from skopt.learning import (RandomForestRegressor, ExtraTreesRegressor,
+                            GradientBoostingQuantileRegressor)
 import numpy as np
 from numpy import inf
 from deephyper.search import util
@@ -14,28 +15,28 @@ class Optimizer:
     def __init__(self,
                 problem,
                 num_workers,
-                learner='RF',
+                surrogate_model='RF',
                 acq_func='gp_hedge',
                 acq_kappa=1.96,
                 liar_strategy='cl_max',
                 n_jobs=1, **kwargs):
 
-        assert learner in ["RF", "ET", "GBRT", "GP", "DUMMY"], f"Unknown scikit-optimize base_estimator: {learner}"
+        assert surrogate_model in ["RF", "ET", "GBRT", "GP", "DUMMY"], f"Unknown scikit-optimize base_estimator: {surrogate_model}"
 
-        if learner == "RF":
+        if surrogate_model == "RF":
             base_estimator = RandomForestRegressor(n_jobs=n_jobs)
-        elif learner == "ET":
+        elif surrogate_model == "ET":
             base_estimator = ExtraTreesRegressor(n_jobs=n_jobs)
-        elif learner == "GBRT":
+        elif surrogate_model == "GBRT":
             base_estimator = GradientBoostingQuantileRegressor(n_jobs=n_jobs)
         else:
-            base_estimator = learner
+            base_estimator = surrogate_model
 
         self.space = problem.space
         # queue of remaining starting points
         self.starting_points = problem.starting_point
 
-        n_init = inf if learner == 'DUMMY' else max(
+        n_init = inf if surrogate_model == 'DUMMY' else max(
             num_workers, len(self.starting_points))
 
         self._optimizer = SkOptimizer(
@@ -52,7 +53,7 @@ class Optimizer:
         self.strategy = liar_strategy
         self.evals = {}
         self.counter = 0
-        logger.info(f"Using skopt.Optimizer with {learner} base_estimator")
+        logger.info(f"Using skopt.Optimizer with {surrogate_model} base_estimator")
 
     def _get_lie(self):
         if self.strategy == "cl_min":

--- a/deephyper/search/nas/ambs.py
+++ b/deephyper/search/nas/ambs.py
@@ -27,13 +27,13 @@ class AMBNeuralArchitectureSearch(NeuralArchitectureSearch):
         problem (str): python attribute import of the ``NaProblem`` instance (e.g. ``mypackage.mymodule.myproblem``).
         run (str): python attribute import of the run function (e.g. ``mypackage.mymodule.myrunfunction``).
         evaluator (str): the name of the evaluator to use.
-        learner (str, optional): Choices are ["RF", "ET", "GBRT", "DUMMY", "GP"]. ``RF`` is Random Forest, ``ET`` is Extra Trees, ``GBRT`` is Gradient Boosting Regression Trees, ``DUMMY`` is random, ``GP`` is Gaussian process. Defaults to "RF".
+        surrogate_model (str, optional): Choices are ["RF", "ET", "GBRT", "DUMMY", "GP"]. ``RF`` is Random Forest, ``ET`` is Extra Trees, ``GBRT`` is Gradient Boosting Regression Trees, ``DUMMY`` is random, ``GP`` is Gaussian process. Defaults to "RF".
         liar_strategy (str, optional): ["cl_max", "cl_min", "cl_mean"]. Defaults to "cl_max".
         acq_func (str, optional): Acquisition function, choices are ["gp_hedge", "LCB", "EI", "PI"]. Defaults to "gp_hedge".
-        n_jobs (int, optional): Number of parallel jobs to distribute the learner. Defaults to -1, means as many as the number of logical cores.
+        n_jobs (int, optional): Number of parallel jobs to distribute the surrogate model (learner). Defaults to -1, means as many as the number of logical cores.
     """
     def __init__(self, problem, run, evaluator,
-                learner="RF",
+                surrogate_model="RF",
                 liar_strategy="cl_max",
                 acq_func="gp_hedge",
                 n_jobs=-1,
@@ -60,15 +60,15 @@ class AMBNeuralArchitectureSearch(NeuralArchitectureSearch):
             ))
 
         dhlogger.info("Initializing AMBS")
-        self.optimizer = Optimizer(self.problem, self.num_workers, learner=learner, liar_strategy=liar_strategy, acq_func=acq_func, n_jobs=n_jobs, **kwargs)
+        self.optimizer = Optimizer(self.problem, self.num_workers, surrogate_model=surrogate_model, liar_strategy=liar_strategy, acq_func=acq_func, n_jobs=n_jobs, **kwargs)
 
     @staticmethod
     def _extend_parser(parser):
         NeuralArchitectureSearch._extend_parser(parser)
-        parser.add_argument('--learner',
+        parser.add_argument('--surrogate-model',
                             default='RF',
                             choices=["RF", "ET", "GBRT", "DUMMY", "GP"],
-                            help='type of learner (surrogate model)'
+                            help='type of surrogate model (learner)'
                             )
         parser.add_argument('--liar-strategy',
                             default="cl_max",
@@ -85,7 +85,7 @@ class AMBNeuralArchitectureSearch(NeuralArchitectureSearch):
         parser.add_argument('--n-jobs',
                             default=-1,
                             type=int,
-                            help='Number of processes to use for learner.')
+                            help='Number of processes to use for surrogate model (learner).')
         return parser
 
     def main(self):

--- a/deephyper/search/nas/baselines/common/atari_wrappers.py
+++ b/deephyper/search/nas/baselines/common/atari_wrappers.py
@@ -84,7 +84,7 @@ class EpisodicLifeEnv(gym.Wrapper):
     def reset(self, **kwargs):
         """Reset only when lives are exhausted.
         This way all states are still reachable even though lives are episodic,
-        and the learner need not know about any of this behind-the-scenes.
+        and the surrogate model (learner) need not know about any of this behind-the-scenes.
         """
         if self.was_real_done:
             obs = self.env.reset(**kwargs)
@@ -247,4 +247,3 @@ def wrap_deepmind(env, episode_life=True, clip_rewards=True, frame_stack=False, 
     if frame_stack:
         env = FrameStack(env, 4)
     return env
-

--- a/deephyper/search/search.py
+++ b/deephyper/search/search.py
@@ -33,7 +33,7 @@ class Search:
         max_evals (int): the maximum number of evaluations to run. The exact behavior related to this parameter can vary in different search.
     """
 
-    def __init__(self, problem: str, run: str, evaluator: str, max_evals: int=100, seed: int=None, **kwargs):
+    def __init__(self, problem: str, run: str, evaluator: str, max_evals: int=1000000, seed: int=None, **kwargs):
         kwargs['problem'] = problem
         kwargs['run'] = run
         kwargs['evaluator'] = evaluator

--- a/docs/run/theta.rst
+++ b/docs/run/theta.rst
@@ -7,34 +7,34 @@ User
 Hyperparameter Search
 ---------------------
 
-First we are going to run a search on ``deephyper.benchmark.hps.polynome2``
-benchmark. In order to achieve this goal we first have to load the deephyper
-module on Theta. This module is bringing deephyper in you current environment
-but also the cray python distribution and the balsam software::
+First we are going to run a search on the ``deephyper.benchmark.hps.polynome2``
+benchmark. In order to achieve this goal we must load the DeepHyper
+module on Theta. This module is not only bringing DeepHyper into you current environment,
+but also the Cray Python distribution and the Balsam software::
 
     module load deephyper
 
-Then you can create a new postgress database in the current directory, this
-database is used by the balsam software::
+Then, you can create a new Postgres database in the current directory; this
+database is used by the Balsam software::
 
     balsam init testdb
 
-Once the database has been created you can start it, or link to it if
+Once the database has been created you can start it or link to it if
 it is already running::
 
     source balsamactivate testdb
 
-The database is now running, let's create our first balsam application
+The database is now running. Let's define our first Balsam application
 in order to run a Asynchronous Model-Based Search (AMBS)::
 
     balsam app --name AMBS --exec "$(which python) -m deephyper.search.hps.ambs"
 
 You can run the following command to print all the applications available
-in your current balsam environment::
+in your current Balsam environment::
 
     balsam ls apps
 
-Then create a new job::
+Create a new job::
 
     balsam job --name test --application AMBS --workflow TEST --args '--evaluator balsam --problem deephyper.benchmark.hps.polynome2.Problem --run deephyper.benchmark.hps.polynome2.run'
 
@@ -48,17 +48,59 @@ Print jobs referenced in Balsam database::
 
         export PROJECT_NAME=datascience
 
-Finally you can submit a cobalt job to Theta which will start by running
+Finally, you can submit a Cobalt job to Theta which will start by running
 your master job named test::
 
     balsam submit-launch -n 128 -q default -t 180 -A $PROJECT_NAME --job-mode serial --wf-filter TEST
 
-
-Now if you want to look at the logs, go to ``testdb/data/TEST``. You'll see
+If you want to look at the logs, navigate to ``testdb/data/TEST``. You'll see
 one directory prefixed with ``test``. Inside this directory you will find the
-logs of you search. All the other directories prefixed with ``task`` correspond
-to the logs of your ``--run`` function, here the run function is corresponding
-to the training of a neural network.
+logs of you search. All the other directories prefixed with ``task`` contain the
+individual logs of each evaluation your ``--run`` function. Here, the run function 
+corresponds to the training of a neural network.
+
+The above specification of Balsam ``--job-mode=serial`` can be used for tasks that **do
+not** use MPI (and hence are restricted to a single node). With the current settings,
+Balsam executes a ``Master`` orchestrator process on the entirety of the first node, and
+each of the remaining 127 nodes will execute isolated DeepHyper "workers". One worker
+(compute node) will execute the AMBS searcher/learner process. The remaining 126 compute
+nodes will execute independent evaluators defined by
+``deephyper.benchmark.hps.polynome2.run``. Only a single call to the job scheduler's
+``mpirun``-equivalent command is made at the beginning of ``submit-launch`` command; jobs
+are run as forked processes on all of the ``Worker`` ranks.
+
+DeepHyper automatically infers the number of available workers from the Balsam environment
+variables ``BALSAM_LAUNCHER_NODES`` and ``BALSAM_JOB_MODE``. Additionally, the user can
+define the ``DEEPHYPER_WORKERS_PER_NODE`` environment variable to pack several tasks per
+node in this Balsam job mode. In that case, the ``--node-packing-count`` option of
+``balsam job`` should be changed from its default value of 1 to be consistent with the
+environment variable and ensure full job occupancy of the ``Worker`` ranks. For example,
+to run 4 DeepHyper workers per node, the above command is modified::
+
+  balsam job --name test --application AMBS --workflow TEST --node-packing-count=4 --env DEEPHYPER_WORKERS_PER_NODE=4 --args '--evaluator balsam --problem deephyper.benchmark.hps.polynome2.Problem --run deephyper.benchmark.hps.polynome2.run'
+
+The resulting behavior is as follows:
+  - ``Node0`` executes the ``Master`` orchestrator process
+  - ``Node1`` executes the AMBS searcher process and 3x DeepHyper evaluators
+  - ``Node2, ..., Node126`` each execute 4x DeepHyper evaluators
+
+.. note::
+   If Balsam is launched in this mode with only one node, ``balsam submit-launch -n 1
+   ...``, the ``Master`` process will share the node with 4x DeepHyper workers. It will
+   not contribute to the worker node occupancy calculations in Balsam.
+    
+The default Balsam job mode is ``--job-mode=mpi``. There are several key differences
+when compared with the serial job mode:
+1. The tasks may or may not use MPI (and multiple nodes).
+2. No more than one task can be executed on a node at a time (current restriction).
+   - Hence, ``DEEPHYPER_WORKERS_PER_NODE`` should be set to 1.
+3. The launcher runs on the head node (or Machine Oriented Mini-server (MOM) node on
+   Theta) and continuously submits jobs using the ``mpirun``-equivalent command for the
+   given job scheduler. There is no notion of a ``Master`` process that consumes a compute
+   node. 
+
+See `Balsam documentation <https://balsam.readthedocs.io/en/latest/userguide/submit/>`_
+for more information. 
 
 Neural Architecture Search
 --------------------------

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIRED = [
     'scikit-optimize',
     'scikit-learn',
     'tqdm',
-    'tensorflow>=1.14.0',
+    'tensorflow>=1.14.0,<2.0.0',
     'keras',
     'deap',  # GA search
     # nas
@@ -49,7 +49,7 @@ REQUIRED = [
 DP_LINKS = list()
 
 if on_rtd:
-    REQUIRED.remove('balsam-flow==0.3.8')
+    REQUIRED.remove('balsam-flow>=0.3.8')
 
 if on_theta:  # --system-site-packages
     # we want to use the default mpi4py from cray environment
@@ -57,7 +57,7 @@ if on_theta:  # --system-site-packages
 elif not on_rtd and not on_gpu:
     REQUIRED.append('mpi4py>=3.0.0')
 elif on_gpu:
-    REQUIRED.append('tensorflow-gpu==1.13.1')
+    REQUIRED.append('tensorflow-gpu>=1.13.1')
     REQUIRED.append('mpi4py')
 else:
     REQUIRED.append('Sphinx>=1.8.2')
@@ -76,7 +76,7 @@ EXTRAS = {
         'jupyter',
         'jupyter_contrib_nbextensions>=0.5.1',
         'pandas>=0.24.2',
-        'seaborn>=0.9.0',
+        'seaborn>=0.9.1',
         'matplotlib>=3.0.3'
     ]
 }
@@ -181,7 +181,7 @@ class TestUploadCommand(Command):
 class TestInstallCommand(Command):
     """Support setup.py testinstall"""
 
-    description = 'Install deephyper from Test Pypi.'
+    description = 'Install deephyper from TestPyPI.'
     user_options = []
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ REQUIRED = [
     'scikit-optimize',
     'scikit-learn',
     'tqdm',
-    'tensorflow==1.14.0',
+    'tensorflow>=1.14.0',
     'keras',
     'deap',  # GA search
     # nas


### PR DESCRIPTION
The calculation of the number of workers available to DeepHyper when `--evaluator balsam` is used was incorrect in many cases, and it was unclear how to modify `DEEPHYPER_WORKERS_PER_NODE` consistently with `balsam job --node-packing-count=X` when serial job mode is used in order to achieve the desired packing on each node.

E.g. consider a 2 node, serial job mode Balsam case with a desired behavior of 5 jobs (1x search + 4x evaluators) operating on the second node. The first node is fully reserved by `Balsam` in this case. In the current `master`,  the following line in DeepHyper
https://github.com/deephyper/deephyper/blob/8293621e069b15176568c3491f069f3684b85f56/deephyper/evaluator/_balsam.py#L34

seems to reserve 2 "workers" from the overall Balsam pool when launching evaluators: 1x for the searcher/learner ABMS process, and 1x presumably for the Balsam `Master` process for the MPI ensemble in the serial job mode.

This implies that the user must execute `balsam job --node-packing-count=3 --env DEEPHYPER_WORKERS_PER_NODE=6 ...` in order to get full occupancy on the **single** node that actually runs Balsam jobs. This is because DeepHyper sets the spawned evaluation jobs with `--node-packing-count=DEEPHYPER_WORKERS_PER_NODE`, even though it only considers `Total number of workers: 4`. The resulting occupancy that Balsam computes for the node will be 4/6 + 1/3 = 1.0

Furthermore, the current `self.num_workers` calculation is clearly incorrect for `--job-mode=mpi`, or `--job-mode=serial` with 1 node. 

With the changes in this PR, the correct user behavior in my above (serial job mode) example is `balsam job --node-packing-count=5 --env DEEPHYPER_WORKERS_PER_NODE=5 ...` (which makes sense to me), and it is fully documented in `docs/run/theta.rst`. This is also the correct usage in the 1 node `--job-mode=serial` edge case, when the `Master` is silently colocated on the node with the Balsam `Worker` rank.  

One thing that was confusing to me during this debugging was the differences between `search/hps/ambs.py` and `search/nas/ambs.py`. Only the latter has the following logic:
https://github.com/deephyper/deephyper/blob/8293621e069b15176568c3491f069f3684b85f56/deephyper/search/nas/ambs.py#L44-L53
Was this an aborted attempt to incorporate the correct `num_workers` logic? Or something else? I have not run any NAS problems with DeepHyper.

I am still not convinced that the terminology of DeepHyper + Balsam is fully consistent/ not misleading. Specifically, that "Worker" in DH includes both the AMBS "searcher"/"learner" + evaluators/runners? This impacts the naming of the environment variables, etc. Here is my current breakdown:
- DeepHyper:
  - Worker:
    - Evaluator/Runner?
    - Learner/searcher?
- Balsam:
  - Job/Task
  - Worker (serial job mode only, I believe)


**Other changes**:
- Avoided a Seaborn v0.9.0 incompatibility with NumPy >=v1.18.x
- Fix Seaborn heatmap plot in HPS analytics notebook
- Make default `max_evals` in `Search` class's `__init__()` consistent with the `argparse` default
- Do not pin specific TF version, but prohibit TF >= 2.0.0

