### PR TITLE
JSON-serialize categorical parameter with numpy bool_ types

### DIFF
--- a/deephyper/evaluator/evaluate.py
+++ b/deephyper/evaluator/evaluate.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from contextlib import suppress as dummy_context
 from math import isnan
 import numpy as np
-from numpy import integer, floating, ndarray
+from numpy import integer, floating, ndarray, bool_
 import json
 import uuid
 import logging
@@ -30,6 +30,8 @@ class Encoder(json.JSONEncoder):
             return int(obj)
         elif isinstance(obj, floating):
             return float(obj)
+        elif isinstance(obj, bool_):
+            return bool(obj)
         elif isinstance(obj, ndarray):
             return obj.tolist()
         elif isinstance(obj, types.FunctionType):


### PR DESCRIPTION
A user observed `TypeError` coming from the evaluator JSON encoder when passed `bool_` types.  This is a numpy boolean datatype which can easily be serialized with this patch.

```
  File "/projects/datascience/cadams/dl-from-source/installation/lib/python3.6/site-packages/deephyper/search/hps/ambs.py", line 115, in main
    self.evaluator.add_eval_batch(batch)
  File "/projects/datascience/cadams/dl-from-source/installation/lib/python3.6/site-packages/deephyper/evaluator/evaluate.py", line 188, in add_eval_batch
    uid = self.add_eval(x)
  File "/projects/datascience/cadams/dl-from-source/installation/lib/python3.6/site-packages/deephyper/evaluator/evaluate.py", line 169, in add_eval
    key = self.encode(x)
  File "/projects/datascience/cadams/dl-from-source/installation/lib/python3.6/site-packages/deephyper/evaluator/evaluate.py", line 148, in encode
    return json.dumps(x, cls=self.encoder)
 
TypeError: Object of type 'bool_' is not JSON serializable
```