### PR TITLE
fix a bug that generated arch seq may be out of bound in ambs

### DIFF
--- a/deephyper/search/nas/ambs.py
+++ b/deephyper/search/nas/ambs.py
@@ -85,7 +85,7 @@ class AMBNeuralArchitectureSearch(NeuralArchitectureSearch):
         skopt_space = cs.ConfigurationSpace(seed=self.problem.seed)
         for i, vnode in enumerate(search_space.variable_nodes):
             hp = csh.UniformIntegerHyperparameter(
-                name=f"vnode_{i}", lower=0, upper=(vnode.num_ops - 1)
+                name=f"vnode_{i:05d}", lower=0, upper=(vnode.num_ops - 1)
             )
             skopt_space.add_hyperparameter(hp)
 


### PR DESCRIPTION
Here is a quick fix for a bug that the generated arch seqs may be out of boundary in AMBS. 

Specifically, the hyperparameters in `skopt_space` are sorted in alphabetical order. Therefore, if a model has more than 10 variable nodes, the name `vnode_{i}` will be sorted incorrectly--- e.g,, vnode 1, vnode 10, vnode 2.... When it generates an arch seq, the arch seq is not corresponding to the seq that the search space required. 

This will cause 
AssertionError: Number of possible operations is: 3, but index given is: 4 (index starts from 0)!

In the quick, I am adding leading some zeros to the vnode numbers, so the problem is fixed. 


