### PR TITLE
Bug Fix

### DIFF
--- a/deephyper/evaluator/_ray_evaluator.py
+++ b/deephyper/evaluator/_ray_evaluator.py
@@ -3,7 +3,7 @@ import subprocess
 import time
 from collections import defaultdict, namedtuple
 import sys
-
+import traceback
 import ray
 
 from deephyper.evaluator.evaluate import Evaluator
@@ -37,6 +37,7 @@ class RayFuture:
                 self._result = ray.get(id_done[0])
                 self._state = "done"
             except Exception:
+                logger.error(traceback.format_exc())
                 self._state = "failed"
         else:
             self._state = "active"

--- a/deephyper/nas/space/node.py
+++ b/deephyper/nas/space/node.py
@@ -111,12 +111,12 @@ class VariableNode(OperationNode):
         self.get_op(index).init(self)
 
     def get_op(self, index):
-        assert (
-            "float" in str(type(index)) or type(index) is int
-        ), f"found type is : {type(index)}"
+        assert ("float" in str(type(index)) or 'int' in str(type(index))), f"found type is : {type(index)}"
+
         if "float" in str(type(index)):
             self._index = self.denormalize(index)
         else:
+            index = int(index)
             assert 0 <= index and index < len(
                 self._ops
             ), f"Number of possible operations is: {len(self._ops)}, but index given is: {index} (index starts from 0)!"


### PR DESCRIPTION
Hi,

The bug happened when I was testing AMBS with Ray backend. 

# Observation: 
I found in results.csv, lots of architectures have negative numbers. Only the first lines were correctly calculated. 


For example, here is a results.csv. Only the first few lines have normal numbers. 
```
0,1,2,3,4,5,6,7,8,9,objective,elapsed_sec
1,1,1,2,2,2,2,1,2,2,0.10100000351667404,32.084259033203125
0,1,3,3,0,0,3,2,2,2,0.9057999849319458,33.299095153808594
3,0,2,0,0,1,3,2,3,1,0.5033000111579895,36.936150789260864
3,0,3,3,1,0,3,1,1,0,0.9332000017166138,34.94940972328186
2,2,3,1,1,0,1,0,3,2,0.0957999974489212,33.211127519607544
3,1,0,0,2,1,1,1,2,1,0.08919999748468399,32.68627071380615
0,1,2,0,2,2,3,1,0,0,0.10279999673366547,49.30409479141235
0,1,3,3,1,3,0,1,1,1,0.8154000043869019,47.84128284454346
0,0,2,3,0,1,2,1,3,1,0.8234000205993652,49.304176807403564
3,2,2,0,1,0,3,1,0,1,0.10100000351667404,50.12700152397156
0,1,3,3,1,0,3,2,3,2,0.9377999901771545,52.92306971549988
3,2,3,3,0,0,3,0,0,1,-3.4028235e+38,37.62176823616028
1,1,0,2,0,1,1,0,2,2,-3.4028235e+38,48.212350845336914
0,1,1,0,0,0,3,1,3,1,-3.4028235e+38,48.59219551086426
0,2,2,2,1,0,1,2,1,2,-3.4028235e+38,48.97624492645264
1,0,3,0,1,0,1,0,3,2,-3.4028235e+38,49.30425572395325
2,0,0,2,2,2,2,0,3,0,-3.4028235e+38,49.81239938735962
1,1,2,3,2,2,1,2,2,1,-3.4028235e+38,50.127103328704834
3,0,1,2,2,3,2,2,1,2,-3.4028235e+38,50.12724256515503
0,0,0,1,2,2,0,0,0,0,-3.4028235e+38,50.74441742897034
```

# Reason
The reason for this problem was there were failures in RayFuture. However, it did not print the exception out. 

After checking the problem, I found that this was due to an assertion in `node.py`. The index of an op is limited to float or int, however, some return values of AMBS `skopt` optimizer was **a list of np.int64**. 

The first lines were correct because they were randomly initialized. (in the beginning phase) Later, `skopt.Optimizer` will generate a lot of lists of np.int64 as arch seqs.  

# Simple Fix
This commit is a quick fix for 1) silent fail from RayFuture 2) type error in `node.py`. 
Please refer to the changes for details... 

After this fix, the `results.csv` looks normal. 






