### PR TITLE
updated tutorial scripts to reflect airline dataset load change

### DIFF
--- a/docs/tutorials/content_hps_ml_advanced/test_best_config.py
+++ b/docs/tutorials/content_hps_ml_advanced/test_best_config.py
@@ -19,7 +19,10 @@ ratio_test = 0.33
 ratio_valid = (1 - ratio_test) * 0.33
 
 train, valid, test = dataset.load_data(
-    random_state=rs_data, test_size=ratio_test, valid_size=ratio_valid,
+    random_state=rs_data,
+    test_size=ratio_test,
+    valid_size=ratio_valid,
+    categoricals_to_integers=True,
 )
 
 clf_class = CLASSIFIERS[config["classifier"]]

--- a/docs/tutorials/content_hps_ml_advanced/test_default_configs.py
+++ b/docs/tutorials/content_hps_ml_advanced/test_default_configs.py
@@ -10,7 +10,10 @@ ratio_test = 0.33
 ratio_valid = (1 - ratio_test) * 0.33
 
 train, valid, test = dataset.load_data(
-    random_state=rs_data, test_size=ratio_test, valid_size=ratio_valid,
+    random_state=rs_data,
+    test_size=ratio_test,
+    valid_size=ratio_valid,
+    categoricals_to_integers=True,
 )
 
 for clf_name, clf_class in CLASSIFIERS.items():

--- a/docs/tutorials/content_hps_ml_basic/load_data.py
+++ b/docs/tutorials/content_hps_ml_basic/load_data.py
@@ -22,7 +22,10 @@ def load_data():
     # The 3rd result is ignored with "_" because it corresponds to the test set
     # which is not interesting for us now.
     (X_train, y_train), (X_valid, y_valid), _ = dataset.load_data(
-        random_state=random_state, test_size=ratio_test, valid_size=ratio_valid
+        random_state=random_state,
+        test_size=ratio_test,
+        valid_size=ratio_valid,
+        categoricals_to_integers=True,
     )
 
     # Uncomment the next line if you want to sub-sample the training data to speed-up


### PR DESCRIPTION
**For the HPS ML Basic tutorial:**
- Ran into a ValueError when attempting to run the deephyper job: `deephyper hps ambs --problem dhproj.rf_tuning.problem.Problem --run dhproj.rf_tuning.model_run.run --max-evals 20 --evaluator subprocess --n-jobs 4`
   - Fixed issue by adding the `categoricals_to_integers=True` option in the `load_data` function called in the `load_data.py` script

**For the HPS ML Advanced tutorial:**
- Similar issue with a ValueError encountered throughout the steps.
   - Solved by adding the `categoricals_to_integers=True` option in the `load_data` function called in the `test_default_configs.py` and `test_best_config.py` scripts