### PR TITLE
Fix type hint for `parse_args`

### DIFF
--- a/deephyper/search/search.py
+++ b/deephyper/search/search.py
@@ -110,7 +110,7 @@ class Search:
         return parser
 
     @classmethod
-    def parse_args(cls, arg_str=None) -> None:
+    def parse_args(cls, arg_str=None) -> argparse.Namespace:
         parser = cls.get_parser()
         if arg_str is not None:
             return parser.parse_args(arg_str)


### PR DESCRIPTION
The class method `parse_args` returns an instance of `argparse.Namespace`, not `None`.