### PR TITLE
Remove any dependence on standalone/external Keras

### DIFF
--- a/deephyper/benchmark/hps/cifar10cnn/data/get_data.py
+++ b/deephyper/benchmark/hps/cifar10cnn/data/get_data.py
@@ -1,5 +1,5 @@
 import os
-from keras.utils.data_utils import get_file
+from tensorflow.keras.utils import get_file
 
 origin = 'https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz'
 here = os.getcwd()

--- a/deephyper/benchmark/hps/mnistmlp-script/load_data.py
+++ b/deephyper/benchmark/hps/mnistmlp-script/load_data.py
@@ -1,5 +1,6 @@
 import os
-from keras.datasets import mnist
+from tensorflow.keras.datasets import mnist
+
 
 def load_data():
     """Loads the MNIST dataset.
@@ -14,6 +15,7 @@ def load_data():
 
     (x_train, y_train), (x_test, y_test) = mnist.load_data(dest)
     return (x_train, y_train), (x_test, y_test)
+
 
 if __name__ == '__main__':
     load_data()

--- a/deephyper/benchmark/hps/mnistmlp-script/mnist_mlp.py
+++ b/deephyper/benchmark/hps/mnistmlp-script/mnist_mlp.py
@@ -4,14 +4,12 @@ Gets to 98.40% test accuracy after 20 epochs
 2 seconds per epoch on a K520 GPU.
 '''
 
-from __future__ import print_function
-
 from load_data import load_data
-from keras.optimizers import RMSprop
-from keras.models import Sequential
-from keras.layers import Dense, Dropout
-from keras.datasets import mnist
-import keras
+
+import tensorflow as tf
+from tensorflow.keras.layers import Dense, Dropout
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers import RMSprop
 
 import os
 import sys
@@ -21,10 +19,7 @@ sys.path.insert(0, here)
 
 def run(param_dict):
     print(param_dict)
-
-    batch_size = 128
     num_classes = 10
-    epochs = 20
 
     # the data, split between train and test sets
     (x_train, y_train), (x_test, y_test) = load_data()
@@ -39,8 +34,8 @@ def run(param_dict):
     print(x_test.shape[0], 'test samples')
 
     # convert class vectors to binary class matrices
-    y_train = keras.utils.to_categorical(y_train, num_classes)
-    y_test = keras.utils.to_categorical(y_test, num_classes)
+    y_train = tf.keras.utils.to_categorical(y_train, num_classes)
+    y_test = tf.keras.utils.to_categorical(y_test, num_classes)
 
     model = Sequential()
     model.add(Dense(

--- a/deephyper/benchmark/hps/mnistmlp/load_data.py
+++ b/deephyper/benchmark/hps/mnistmlp/load_data.py
@@ -1,5 +1,6 @@
 import os
-from keras.datasets import mnist
+from tensorflowkeras.datasets import mnist
+
 
 def load_data():
     """Loads the MNIST dataset.
@@ -14,6 +15,7 @@ def load_data():
 
     (x_train, y_train), (x_test, y_test) = mnist.load_data(dest)
     return (x_train, y_train), (x_test, y_test)
+
 
 if __name__ == '__main__':
     load_data()

--- a/deephyper/benchmark/hps/mnistmlp/mnist_mlp.py
+++ b/deephyper/benchmark/hps/mnistmlp/mnist_mlp.py
@@ -4,23 +4,17 @@ Gets to 98.40% test accuracy after 20 epochs
 2 seconds per epoch on a K520 GPU.
 '''
 
-from __future__ import print_function
-
-import keras
-from keras.datasets import mnist
-from keras.layers import Dense, Dropout
-from keras.models import Sequential
-from keras.optimizers import RMSprop
+import tensorflow as tf
+from tensorflow.keras.layers import Dense, Dropout
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers import RMSprop
 
 from deephyper.benchmark.hps.mnistmlp.load_data import load_data
 
 
 def run(param_dict):
     print(param_dict)
-
-    batch_size = 128
     num_classes = 10
-    epochs = 20
 
     # the data, split between train and test sets
     (x_train, y_train), (x_test, y_test) = load_data()
@@ -35,8 +29,8 @@ def run(param_dict):
     print(x_test.shape[0], 'test samples')
 
     # convert class vectors to binary class matrices
-    y_train = keras.utils.to_categorical(y_train, num_classes)
-    y_test = keras.utils.to_categorical(y_test, num_classes)
+    y_train = tf.keras.utils.to_categorical(y_train, num_classes)
+    y_test = tf.keras.utils.to_categorical(y_test, num_classes)
 
     model = Sequential()
     model.add(Dense(

--- a/deephyper/benchmark/nas/ptb/load_data.py
+++ b/deephyper/benchmark/nas/ptb/load_data.py
@@ -3,10 +3,6 @@ Created by Dipendra Jha (dipendra@u.northwestern.edu) on 7/24/18
 
 Utilities for parsing PTB text files.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import collections
 import os
 import sys
@@ -18,10 +14,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 def _read_words(filename):
   with tf.gfile.GFile(filename, "r") as f:
-    if sys.version_info[0] >= 3:
-      return f.read().replace("\n", "<eos>").split()
-    else:
-      return f.read().decode("utf-8").replace("\n", "<eos>").split()
+    return f.read().replace("\n", "<eos>").split()
 
 
 def _build_vocab(filename):
@@ -48,7 +41,6 @@ def _create_input_output(raw_data, batch_size, num_steps):
     epoch_size = (batch_len-1)//num_steps
     print(data_len, batch_len, epoch_size)
     assert epoch_size > 0, "epoch_size == 0, decrease batch_size or num_steps"
-    start_inds = range(epoch_size)
     X = np.reshape(data[:,:epoch_size*num_steps], (batch_size, epoch_size, num_steps))
     Y = np.reshape(data[:,1:epoch_size*num_steps+1], (batch_size, epoch_size, num_steps))
     print (X.shape, Y.shape)
@@ -82,7 +74,7 @@ def load_data(config=None):
     batch_size = 32
     if config and 'batch_size' in config: batch_size = config['batch_size']
     if config and 'num_steps' in config: num_steps = config['num_steps']
-    #if config and 'dest' in config: data_path = config['dest']
+    # if config and 'dest' in config: data_path = config['dest']
     train_path = os.path.join(data_path, "ptb.train.txt")
     valid_path = os.path.join(data_path, "ptb.valid.txt")
     test_path = os.path.join(data_path, "ptb.test.txt")
@@ -91,7 +83,7 @@ def load_data(config=None):
     train_data = _file_to_word_ids(train_path, word_to_id)
     valid_data = _file_to_word_ids(valid_path, word_to_id)
     test_data = _file_to_word_ids(test_path, word_to_id)
-    train_X, train_y = _create_input_output(train_data,batch_size, num_steps)
+    train_X, train_y = _create_input_output(train_data, batch_size, num_steps)
     valid_X, valid_y = _create_input_output(valid_data, batch_size, num_steps)
     test_X, test_y = _create_input_output(test_data, batch_size, num_steps)
     return (train_X, train_y), (valid_X, valid_y), (test_X, test_y), word_to_id

--- a/deephyper/benchmark/util.py
+++ b/deephyper/benchmark/util.py
@@ -25,6 +25,8 @@ def str2bool(s):
         return False
     else:
         return True
+
+
 class Timer:
     def __init__(self):
         self.t0 = 0.0
@@ -50,7 +52,6 @@ def extension_from_parameters(param_dict):
         "data_source",
         "stage_in_destination",
         "version",
-        "backend",
     ]
     extension = ""
     for key in sorted(param_dict):
@@ -72,7 +73,7 @@ def load_meta_data(filename):
 
 
 def resume_from_disk(benchmark_name, param_dict, data_dir="", custom_objects={}):
-    from keras.models import load_model
+    from tensorflow.keras.models import load_model
 
     SavedModel = namedtuple(
         "SavedModel", ["model", "model_path", "initial_epoch", "model_mda_path"]
@@ -118,7 +119,7 @@ def resume_from_disk(benchmark_name, param_dict, data_dir="", custom_objects={})
 
 
 def stage_in(file_names, source, dest):
-    from keras.utils.data_utils import get_file
+    from tensorflow.keras.utils import get_file
 
     print("Stage in files:", file_names)
     print("From source dir:", source)

--- a/deephyper/contrib/callbacks/learning_rate_warmup.py
+++ b/deephyper/contrib/callbacks/learning_rate_warmup.py
@@ -2,7 +2,7 @@
 Adapted from Horovod implementation: https://github.com/horovod/horovod/blob/master/horovod/keras/callbacks.py
 """
 import tensorflow as tf
-import tensorflow.keras.backend as K
+
 
 class LearningRateScheduleCallback(tf.keras.callbacks.Callback):
     def __init__(
@@ -17,7 +17,6 @@ class LearningRateScheduleCallback(tf.keras.callbacks.Callback):
         *args
     ):
         super(LearningRateScheduleCallback, self).__init__(*args)
-        self.backend = K
         self.start_epoch = start_epoch
         self.end_epoch = end_epoch
         self.staircase = staircase
@@ -52,25 +51,25 @@ class LearningRateScheduleCallback(tf.keras.callbacks.Callback):
             )
 
     def _adjust_learning_rate(self, epoch):
-        old_lr = self.backend.get_value(self.model.optimizer.lr)
+        old_lr = tf.keras.backend.get_value(self.model.optimizer.lr)
         new_lr = self.initial_lr * self.multiplier(epoch)
-        self.backend.set_value(self.model.optimizer.lr, new_lr)
+        tf.keras.backend.set_value(self.model.optimizer.lr, new_lr)
 
         if hasattr(self.model.optimizer, "momentum") and self.momentum_correction:
             # See the paper cited above for more information about momentum correction.
-            self.restore_momentum = self.backend.get_value(self.model.optimizer.momentum)
-            self.backend.set_value(
+            self.restore_momentum = tf.keras.backend.get_value(self.model.optimizer.momentum)
+            tf.keras.backend.set_value(
                 self.model.optimizer.momentum, self.restore_momentum * new_lr / old_lr
             )
 
     def _restore_momentum_if_needed(self):
         if self.restore_momentum:
-            self.backend.set_value(self.model.optimizer.momentum, self.restore_momentum)
+            tf.keras.backend.set_value(self.model.optimizer.momentum, self.restore_momentum)
             self.restore_momentum = None
 
     def on_train_begin(self, logs=None):
         if self.initial_lr is None:
-            self.initial_lr = self.backend.get_value(self.model.optimizer.lr)
+            self.initial_lr = tf.keras.backend.get_value(self.model.optimizer.lr)
         if not self.staircase and not self.steps_per_epoch:
             self.steps_per_epoch = self._autodetect_steps_per_epoch()
 
@@ -97,7 +96,7 @@ class LearningRateScheduleCallback(tf.keras.callbacks.Callback):
     def on_epoch_end(self, epoch, logs=None):
         if logs is not None:
             # Log current learning rate.
-            logs["lr"] = self.backend.get_value(self.model.optimizer.lr)
+            logs["lr"] = tf.keras.backend.get_value(self.model.optimizer.lr)
 
 
 class LearningRateWarmupCallback(LearningRateScheduleCallback):
@@ -133,7 +132,7 @@ class LearningRateWarmupCallback(LearningRateScheduleCallback):
         super(LearningRateWarmupCallback, self).on_epoch_end(epoch, logs)
 
         if epoch == self.end_epoch - 1 and self.verbose > 0:
-            new_lr = self.backend.get_value(self.model.optimizer.lr)
+            new_lr = tf.keras.backend.get_value(self.model.optimizer.lr)
             print(
                 "\nEpoch %d: finished gradual learning rate warmup to %g."
                 % (epoch + 1, new_lr)

--- a/deephyper/contrib/layers/stack_mpnn.py
+++ b/deephyper/contrib/layers/stack_mpnn.py
@@ -1,7 +1,6 @@
 import tensorflow as tf
 from tensorflow.keras import activations
 from tensorflow.keras.layers import Dense
-import tensorflow.keras.backend as K
 
 
 class SPARSE_MPNN(tf.keras.layers.Layer):
@@ -178,7 +177,7 @@ class Message_Passer_NNM(tf.keras.layers.Layer):
         """
         # Edge network to transform edge information to message weight
         X, A, E, degree = inputs
-        N = K.int_shape(X)[1]
+        N = tf.keras.backend.int_shape(X)[1]
         targets, sources = A[..., -2], A[..., -1]
         W = self.nn(E)
         W = tf.reshape(
@@ -215,7 +214,7 @@ class Message_Passer_NNM(tf.keras.layers.Layer):
         # Output the mean of all attention heads
         output = tf.reshape(output, [-1, N, self.attn_heads, self.state_dim])
         output = tf.reduce_mean(output, axis=-2)
-        output = K.bias_add(output, self.bias)
+        output = tf.keras.backend.bias_add(output, self.bias)
         return output
 
 
@@ -246,8 +245,8 @@ class Update_Func_GRU(tf.keras.layers.Layer):
         """
         # Remember node dim
         old_state, agg_messages = inputs
-        B, N, F = K.int_shape(old_state)
-        B1, N1, F1 = K.int_shape(agg_messages)
+        B, N, F = tf.keras.backend.int_shape(old_state)
+        B1, N1, F1 = tf.keras.backend.int_shape(agg_messages)
         # Reshape so GRU can be applied, concat so old_state and messages are in sequence
         old_state = tf.reshape(old_state, [-1, 1, F])
         agg_messages = tf.reshape(agg_messages, [-1, 1, F1])
@@ -720,7 +719,7 @@ class GlobalAttentionPool(tf.keras.layers.Layer):
         inputs_linear = self.features_layer(inputs)
         attn = self.attention_layer(inputs)
         masked_inputs = inputs_linear * attn
-        output = K.sum(masked_inputs, axis=-2, keepdims=False)
+        output = tf.keras.backend.sum(masked_inputs, axis=-2, keepdims=False)
         return output
 
 
@@ -754,10 +753,10 @@ class GlobalAttentionSumPool(tf.keras.layers.Layer):
             GlobalAttentionSumPool tensor (tensor)
         """
         X = inputs
-        attn_coeff = K.dot(X, self.attn_kernel)
-        attn_coeff = K.squeeze(attn_coeff, -1)
-        attn_coeff = K.softmax(attn_coeff)
-        output = K.batch_dot(attn_coeff, X)
+        attn_coeff = tf.keras.backend.dot(X, self.attn_kernel)
+        attn_coeff = tf.keras.backend.squeeze(attn_coeff, -1)
+        attn_coeff = tf.nn.softmax(attn_coeff)
+        output = tf.keras.backend.batch_dot(attn_coeff, X)
         return output
 
 

--- a/deephyper/contrib/layers/timestep_dropout.py
+++ b/deephyper/contrib/layers/timestep_dropout.py
@@ -1,5 +1,4 @@
 import tensorflow as tf
-import tensorflow.keras.backend as K
 
 
 class TimestepDropout(tf.keras.layers.Dropout):
@@ -27,6 +26,6 @@ class TimestepDropout(tf.keras.layers.Dropout):
         self.input_spec = tf.keras.layers.InputSpec(ndim=3)
 
     def _get_noise_shape(self, inputs):
-        input_shape = K.shape(inputs)
+        input_shape = tf.shape(inputs)
         noise_shape = (input_shape[0], input_shape[1], 1)
         return noise_shape

--- a/deephyper/contrib/perf/theta.py
+++ b/deephyper/contrib/perf/theta.py
@@ -1,12 +1,12 @@
 import os
 import tensorflow as tf
-from tensorflow.keras import backend as K
 
 
 """Performance settings for Theta
 
 OMP_NUM_THREADS='128' should be set before importing tensorflow
 """
+
 
 def get_session_conf():
     """Set env variables for better performance on Theta.
@@ -24,12 +24,11 @@ def get_session_conf():
 
     return session_conf
 
+
 def set_perf_settings_for_keras():
     """Set a session with performance setting for keras backend.
     """
     if not(os.environ.get('HOST') is None) and 'theta' in os.environ.get('HOST'):
         session_conf = get_session_conf()
         session = tf.Session(config=session_conf)
-        K.set_session(session)
-
-
+        tf.compat.v1.keras.backend.set_session(session)

--- a/deephyper/core/cli/templates/hps/model_run.py.tmpl
+++ b/deephyper/core/cli/templates/hps/model_run.py.tmpl
@@ -1,10 +1,9 @@
 import numpy as np
-import keras.backend as K
-import keras
-from keras.callbacks import EarlyStopping
-from keras.layers import Dense
-from keras.models import Sequential
-from keras.optimizers import RMSprop
+import tensorflow as tf
+from tensorflow.keras.callbacks import EarlyStopping
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers import RMSprop
 
 import os
 import sys
@@ -12,12 +11,10 @@ import sys
 from {{ pckg }}.{{ pb_folder }}.load_data import load_data
 
 def r2(y_true, y_pred):
-    SS_res = keras.backend.sum(keras.backend.square(y_true - y_pred), axis=0)
-    SS_tot = keras.backend.sum(
-        keras.backend.square(y_true - keras.backend.mean(y_true, axis=0)), axis=0
-    )
-    output_scores = 1 - SS_res / (SS_tot + keras.backend.epsilon())
-    r2 = keras.backend.mean(output_scores)
+    SS_res = tf.math.reduce_sum(tf.math.square(y_true - y_pred), axis=0)
+    SS_tot = tf.math.reduce_sum(tf.math.square(y_true - tf.math.reduce_mean(y_true, axis=0)), axis=0)
+    output_scores = 1 - SS_res / (SS_tot + tf.keras.backend.epsilon())
+    r2 = tf.math.reduce_mean(output_scores)
     return r2
 
 

--- a/deephyper/evaluator/_balsam.py
+++ b/deephyper/evaluator/_balsam.py
@@ -143,7 +143,7 @@ class BalsamEvaluator(Evaluator):
 
     def _create_balsam_task(self, x):
         args = f"'{self.encode(x)}'"
-        envs = f"KERAS_BACKEND={self.KERAS_BACKEND}:KMP_BLOCK_TIME=0"
+        envs = "KMP_BLOCK_TIME=0"
 
         ranks_per_node = self.num_ranks_per_node
         threads_per_rank = self.num_threads_per_rank

--- a/deephyper/evaluator/evaluate.py
+++ b/deephyper/evaluator/evaluate.py
@@ -31,8 +31,6 @@ class Evaluator:
 
     FAIL_RETURN_VALUE = np.finfo(np.float32).min
     PYTHON_EXE = os.environ.get("DEEPHYPER_PYTHON_BACKEND", sys.executable)
-    KERAS_BACKEND = os.environ.get("KERAS_BACKEND", "tensorflow")
-    os.environ["KERAS_BACKEND"] = KERAS_BACKEND
     assert os.path.isfile(PYTHON_EXE)
 
     def __init__(

--- a/deephyper/layers/padding.py
+++ b/deephyper/layers/padding.py
@@ -1,15 +1,21 @@
 import tensorflow as tf
-from tensorflow import keras
 
-class Padding(keras.layers.Layer):
+
+class Padding(tf.keras.layers.Layer):
 
     """Multi-dimensions padding layer.
 
-    This operation pads a tensor according to the paddings you specify. paddings is an integer tensor with shape [n-1, 2], where n is the rank of tensor. For each dimension D of input, paddings[D, 0] indicates how many values to add before the contents of tensor in that dimension, and paddings[D, 1] indicates how many values to add after the contents of tensor in that dimension. The first dimension corresponding to the batch size cannot be padded.
+    This operation pads a tensor according to the paddings you specify. paddings is an
+    integer tensor with shape [n-1, 2], where n is the rank of tensor. For each dimension
+    D of input, paddings[D, 0] indicates how many values to add before the contents of
+    tensor in that dimension, and paddings[D, 1] indicates how many values to add after
+    the contents of tensor in that dimension. The first dimension corresponding to the
+    batch size cannot be padded.
 
     Args:
         padding (list(list(int))): e.g. [[1, 1]]
         mode (str): 'CONSTANT', 'REFLECT' or 'SYMMETRIC'
+
     """
 
     def __init__(self, padding, mode="CONSTANT", constant_values=0, **kwargs):
@@ -27,7 +33,7 @@ class Padding(keras.layers.Layer):
             constant_values=self.constant_values)
 
     def compute_output_shape(self, input_shape):
-        return tf.TensorShape([input_shape[i]+sum(self.padding[i]) if not input_shape[i] is None else None for i in range(len(input_shape))])
+        return tf.TensorShape([input_shape[i] + sum(self.padding[i]) if not input_shape[i] is None else None for i in range(len(input_shape))])
 
     def get_config(self):
         config = {

--- a/deephyper/nas/metrics.py
+++ b/deephyper/nas/metrics.py
@@ -10,24 +10,28 @@ import functools
 import tensorflow as tf
 from deephyper.search import util
 
+
 def r2(y_true, y_pred):
-    SS_res = tf.keras.backend.sum(tf.keras.backend.square(y_true - y_pred), axis=0)
-    SS_tot = tf.keras.backend.sum(
-        tf.keras.backend.square(y_true - tf.keras.backend.mean(y_true, axis=0)), axis=0
+    SS_res = tf.math.reduce_sum(tf.math.square(y_true - y_pred), axis=0)
+    SS_tot = tf.math.reduce_sum(
+        tf.math.square(y_true - tf.math.reduce_mean(y_true, axis=0)), axis=0
     )
     output_scores = 1 - SS_res / (SS_tot + tf.keras.backend.epsilon())
-    r2 = tf.keras.backend.mean(output_scores)
+    r2 = tf.math.reduce_mean(output_scores)
     return r2
 
 
 def mae(y_true, y_pred):
     return tf.keras.metrics.mean_absolute_error(y_true, y_pred)
 
+
 def mse(y_true, y_pred):
     return tf.keras.metrics.mean_squared_error(y_true, y_pred)
 
+
 def rmse(y_true, y_pred):
-        return tf.math.sqrt(tf.math.reduce_mean(tf.math.square(y_pred - y_true)))
+    return tf.math.sqrt(tf.math.reduce_mean(tf.math.square(y_pred - y_true)))
+
 
 def acc(y_true, y_pred):
     return tf.keras.metrics.categorical_accuracy(y_true, y_pred)
@@ -52,6 +56,7 @@ def to_tfp(metric_func):
     wrapper.__name__ = f"tfp_{metric_func.__name__}"
 
     return wrapper
+
 
 # convert some metrics for Tensorflow Probability where the output of the model is
 # a distribution

--- a/deephyper/nas/run/alpha.py
+++ b/deephyper/nas/run/alpha.py
@@ -23,6 +23,7 @@ logger = util.conf_logger("deephyper.search.nas.run")
 
 def run(config):
 
+    tf.keras.backend.clear_session()
     # tf.config.optimizer.set_jit(True)
 
     # setup history saver

--- a/deephyper/nas/run/alpha.py
+++ b/deephyper/nas/run/alpha.py
@@ -23,7 +23,6 @@ logger = util.conf_logger("deephyper.search.nas.run")
 
 def run(config):
 
-    tf.keras.backend.clear_session()
     # tf.config.optimizer.set_jit(True)
 
     # setup history saver

--- a/deephyper/nas/run/repeat.py
+++ b/deephyper/nas/run/repeat.py
@@ -9,7 +9,6 @@
     )
 """
 import numpy as np
-import tensorflow as tf
 
 from deephyper.search import util
 from deephyper.nas.run.alpha import run as run_alpha
@@ -26,7 +25,6 @@ def run(config: dict) -> float:
 
     res_list = []
     for i in range(repeat):
-        tf.keras.backend.clear_session()
         if seed is not None:
             config["seed"] = seeds[i]
         res = run_alpha(config)

--- a/deephyper/nas/run/repeat.py
+++ b/deephyper/nas/run/repeat.py
@@ -9,6 +9,7 @@
     )
 """
 import numpy as np
+import tensorflow as tf
 
 from deephyper.search import util
 from deephyper.nas.run.alpha import run as run_alpha
@@ -25,6 +26,7 @@ def run(config: dict) -> float:
 
     res_list = []
     for i in range(repeat):
+        tf.keras.backend.clear_session()
         if seed is not None:
             config["seed"] = seeds[i]
         res = run_alpha(config)

--- a/deephyper/nas/train_utils.py
+++ b/deephyper/nas/train_utils.py
@@ -1,9 +1,7 @@
 from collections import OrderedDict
 
 import tensorflow as tf
-import tensorflow.keras.backend as K
 
-from deephyper.search import util
 
 optimizers_keras = OrderedDict()
 optimizers_keras["sgd"] = tf.keras.optimizers.SGD
@@ -17,7 +15,7 @@ optimizers_keras["nadam"] = tf.keras.optimizers.Nadam
 
 def selectOptimizer_keras(name):
     """Return the optimizer defined by name."""
-    if optimizers_keras.get(name) == None:
+    if optimizers_keras.get(name) is None:
         raise RuntimeError('"{0}" is not a defined optimizer for keras.'.format(name))
     else:
         return optimizers_keras[name]
@@ -32,4 +30,3 @@ def check_data_config(data_dict):
         return "ndarray"
     else:
         raise RuntimeError("Wrong data config...")
-

--- a/deephyper/post/pipeline.py
+++ b/deephyper/post/pipeline.py
@@ -5,7 +5,6 @@ import copy
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import keras
 
 from deephyper.core.exceptions import DeephyperRuntimeError
 from deephyper.evaluator.encoder import Encoder
@@ -55,6 +54,7 @@ def train(config):
         seeds = [np.random.randint(0, 2 ** 32 - 1) for _ in range(repeat)]
 
     for rep in range(repeat):
+        tf.keras.backend.clear_session()
 
         default_callbacks_config = copy.deepcopy(CB_CONFIG)
         if seed is not None:
@@ -103,7 +103,7 @@ def train(config):
                                 "filepath"
                             ] = f'best_model_id{config["id"]}_r{rep}.h5'
 
-                        Callback = getattr(keras.callbacks, cb_name)
+                        Callback = getattr(tf.keras.callbacks, cb_name)
                         callbacks.append(Callback(**default_callbacks_config[cb_name]))
 
                         logger.info(

--- a/deephyper/post/pipeline.py
+++ b/deephyper/post/pipeline.py
@@ -6,7 +6,6 @@ import copy
 import numpy as np
 import tensorflow as tf
 from tensorflow import keras
-import tensorflow.keras.backend as K
 
 from deephyper.core.exceptions import DeephyperRuntimeError
 from deephyper.evaluator.encoder import Encoder
@@ -45,7 +44,7 @@ CB_CONFIG = {
 def train(config):
     seed = config["seed"]
 
-    if not "post_train" in config:
+    if "post_train" not in config:
         raise DeephyperRuntimeError("The post training was not define in the Problem!")
 
     repeat = config["post_train"]["repeat"]
@@ -56,7 +55,6 @@ def train(config):
         seeds = [np.random.randint(0, 2 ** 32 - 1) for _ in range(repeat)]
 
     for rep in range(repeat):
-        tf.keras.backend.clear_session()
 
         default_callbacks_config = copy.deepcopy(CB_CONFIG)
         if seed is not None:

--- a/deephyper/post/train.py
+++ b/deephyper/post/train.py
@@ -196,9 +196,6 @@ class Manager:
             help="Path to the 'json' file containing the list of best search_spaces. ",
         )
         parser.add_argument(
-            "--backend", default="tensorflow", help="Keras backend module name"
-        )
-        parser.add_argument(
             "--evaluator",
             default="subprocess",
             choices=["balsam", "subprocess"],

--- a/deephyper/search/search.py
+++ b/deephyper/search/search.py
@@ -134,9 +134,6 @@ class Search:
             help="Module path to the run function you want to use for the search.",
         )
         parser.add_argument(
-            "--backend", default="tensorflow", help="Keras backend module name"
-        )
-        parser.add_argument(
             "--max-evals", type=int, default=1000000, help="maximum number of evaluations"
         )
         parser.add_argument(

--- a/docs/tutorials/polynome2/model_run_step_0.py
+++ b/docs/tutorials/polynome2/model_run_step_0.py
@@ -1,10 +1,9 @@
 import numpy as np
-import keras.backend as K
-import keras
-from keras.callbacks import EarlyStopping
-from keras.layers import Dense
-from keras.models import Sequential
-from keras.optimizers import RMSprop
+import tensorflow as tf
+from tensorflow.keras.callbacks import EarlyStopping
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers import RMSprop
 
 import os
 import sys
@@ -15,12 +14,10 @@ from load_data import load_data
 
 
 def r2(y_true, y_pred):
-    SS_res = keras.backend.sum(keras.backend.square(y_true - y_pred), axis=0)
-    SS_tot = keras.backend.sum(
-        keras.backend.square(y_true - keras.backend.mean(y_true, axis=0)), axis=0
-    )
-    output_scores = 1 - SS_res / (SS_tot + keras.backend.epsilon())
-    r2 = keras.backend.mean(output_scores)
+    SS_res = tf.math.reduce_sum(tf.math.square(y_true - y_pred), axis=0)
+    SS_tot = tf.math.reduce_sum(tf.math.square(y_true - tf.math.reduce_mean(y_true, axis=0)), axis=0)
+    output_scores = 1 - SS_res / (SS_tot + tf.keras.backend.epsilon())
+    r2 = tf.math.reduce_mean(output_scores)
     return r2
 
 

--- a/docs/tutorials/polynome2/model_run_step_1.py
+++ b/docs/tutorials/polynome2/model_run_step_1.py
@@ -1,10 +1,9 @@
 import numpy as np
-import keras.backend as K
-import keras
-from keras.callbacks import EarlyStopping
-from keras.layers import Dense
-from keras.models import Sequential
-from keras.optimizers import RMSprop
+import tensorflow as tf
+from tensorflow.keras.callbacks import EarlyStopping
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers import RMSprop
 
 import os
 import sys
@@ -15,12 +14,10 @@ from load_data import load_data
 
 
 def r2(y_true, y_pred):
-    SS_res = keras.backend.sum(keras.backend.square(y_true - y_pred), axis=0)
-    SS_tot = keras.backend.sum(
-        keras.backend.square(y_true - keras.backend.mean(y_true, axis=0)), axis=0
-    )
-    output_scores = 1 - SS_res / (SS_tot + keras.backend.epsilon())
-    r2 = keras.backend.mean(output_scores)
+    SS_res = tf.math.reduce_sum(tf.math.square(y_true - y_pred), axis=0)
+    SS_tot = tf.math.reduce_sum(tf.math.square(y_true - tf.math.reduce_mean(y_true, axis=0)), axis=0)
+    output_scores = 1 - SS_res / (SS_tot + tf.keras.backend.epsilon())
+    r2 = tf.math.reduce_mean(output_scores)
     return r2
 
 
@@ -30,10 +27,10 @@ HISTORY = None
 def run(point):
     global HISTORY
     (x_train, y_train), (x_valid, y_valid) = load_data()
-    
+
     if point["activation"] == "identity":
         point["activation"] = None
-    	
+
     model = Sequential()
     model.add(
         Dense(

--- a/docs/tutorials/polynome2/model_run_step_1_point.py
+++ b/docs/tutorials/polynome2/model_run_step_1_point.py
@@ -1,26 +1,23 @@
-
 import numpy as np
-import keras.backend as K
-import keras
-from keras.callbacks import EarlyStopping
-from keras.layers import Dense
-from keras.models import Sequential
-from keras.optimizers import RMSprop
+import tensorflow as tf
+from tensorflow.keras.callbacks import EarlyStopping
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers import RMSprop
 
 import os
 import sys
+
 here = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, here)
 from load_data import load_data
 
 
 def r2(y_true, y_pred):
-    SS_res = keras.backend.sum(keras.backend.square(y_true - y_pred), axis=0)
-    SS_tot = keras.backend.sum(
-        keras.backend.square(y_true - keras.backend.mean(y_true, axis=0)), axis=0
-    )
-    output_scores = 1 - SS_res / (SS_tot + keras.backend.epsilon())
-    r2 = keras.backend.mean(output_scores)
+    SS_res = tf.math.reduce_sum(tf.math.square(y_true - y_pred), axis=0)
+    SS_tot = tf.math.reduce_sum(tf.math.square(y_true - tf.math.reduce_mean(y_true, axis=0)), axis=0)
+    output_scores = 1 - SS_res / (SS_tot + tf.keras.backend.epsilon())
+    r2 = tf.math.reduce_mean(output_scores)
     return r2
 
 

--- a/docs/user_guides/balsamjob_demo/model_run.py
+++ b/docs/user_guides/balsamjob_demo/model_run.py
@@ -1,24 +1,20 @@
 import numpy as np
-import keras.backend as K
-import keras
-from keras.callbacks import EarlyStopping
-from keras.layers import Dense
-from keras.models import Sequential
-from keras.optimizers import RMSprop
+import tensorflow as tf
+from tensorflow.keras.callbacks import EarlyStopping
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers import RMSprop
 
-import os
 import sys
 
 from polynome2.load_data import load_data
 
 
 def r2(y_true, y_pred):
-    SS_res = keras.backend.sum(keras.backend.square(y_true - y_pred), axis=0)
-    SS_tot = keras.backend.sum(
-        keras.backend.square(y_true - keras.backend.mean(y_true, axis=0)), axis=0
-    )
-    output_scores = 1 - SS_res / (SS_tot + keras.backend.epsilon())
-    r2 = keras.backend.mean(output_scores)
+    SS_res = tf.math.reduce_sum(tf.math.square(y_true - y_pred), axis=0)
+    SS_tot = tf.math.reduce_sum(tf.math.square(y_true - tf.math.reduce_mean(y_true, axis=0)), axis=0)
+    output_scores = 1 - SS_res / (SS_tot + tf.keras.backend.epsilon())
+    r2 = tf.math.reduce_mean(output_scores)
     return r2
 
 

--- a/docs/user_guides/balsamjob_demo/model_run_balsam.py
+++ b/docs/user_guides/balsamjob_demo/model_run_balsam.py
@@ -1,24 +1,18 @@
 import numpy as np
-import keras.backend as K
-import keras
-from keras.callbacks import EarlyStopping
-from keras.layers import Dense
-from keras.models import Sequential
-from keras.optimizers import RMSprop
-
-import os
-import sys
+import tensorflow as tf
+from tensorflow.keras.callbacks import EarlyStopping
+from tensorflow.keras.layers import Dense
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.optimizers import RMSprop
 
 from polynome2.load_data import load_data
 
 
 def r2(y_true, y_pred):
-    SS_res = keras.backend.sum(keras.backend.square(y_true - y_pred), axis=0)
-    SS_tot = keras.backend.sum(
-        keras.backend.square(y_true - keras.backend.mean(y_true, axis=0)), axis=0
-    )
-    output_scores = 1 - SS_res / (SS_tot + keras.backend.epsilon())
-    r2 = keras.backend.mean(output_scores)
+    SS_res = tf.math.reduce_sum(tf.math.square(y_true - y_pred), axis=0)
+    SS_tot = tf.math.reduce_sum(tf.math.square(y_true - tf.math.reduce_mean(y_true, axis=0)), axis=0)
+    output_scores = 1 - SS_res / (SS_tot + tf.keras.backend.epsilon())
+    r2 = tf.math.reduce_mean(output_scores)
     return r2
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ REQUIRED = [
     "dh-scikit-optimize==0.8.3",
     "scikit-learn>=0.23.1",
     "tqdm",
-    "keras",
     "deap",  # GA search
     # nas
     "networkx",


### PR DESCRIPTION
- Remove `keras` from `setup.py`
- Replace all references to standalone Keras with references to `tf.keras`
- Minimize use of `tf.keras.backend`, when possible 

I haven't exhaustively tested this branch. 

Also we should still reduce the use of `tf.keras.backend` functions that are not in the public API, especially in `deephyper/contrib/layers/stack_mpnn.py` and `deephyper/contrib/callbacks/learning_rate_warmup.py`. Compare https://www.tensorflow.org/api_docs/python/tf/keras/backend to https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/keras/backend.py

Closes #88. 