### PR TITLE
Correct typo

### DIFF
--- a/deephyper/search/hps/_ambs.py
+++ b/deephyper/search/hps/_ambs.py
@@ -19,7 +19,7 @@ MAP_acq_func = {
 
 
 class AMBS(Search):
-    """Asynchronous Model-Based Search baised on the `Scikit-Optimized Optimizer <https://scikit-optimize.github.io/stable/modules/generated/skopt.Optimizer.html#skopt.Optimizer>`_.
+    """Asynchronous Model-Based Search based on the `Scikit-Optimized Optimizer <https://scikit-optimize.github.io/stable/modules/generated/skopt.Optimizer.html#skopt.Optimizer>`_.
 
     Args:
         problem (HpProblem): Hyperparameter problem describing the search space to explore.


### PR DESCRIPTION
"baised" ==> "based"