### PR TITLE
Expanded surrogate_model to allow for own sklearn regressor in _cbo.py and _dbo.py

### DIFF
--- a/deephyper/search/hps/_cbo.py
+++ b/deephyper/search/hps/_cbo.py
@@ -97,7 +97,7 @@ class CBO(Search):
             base_estimator = self._get_surrogate_model(
                 surrogate_model,
                 n_jobs,
-                random_state=self._random_state.randint(0, 2 ** 32),
+                random_state=self._random_state.randint(0, 2**32),
             )
         elif is_regressor(surrogate_model):
             base_estimator = surrogate_model


### PR DESCRIPTION
Addresses the second half of https://github.com/deephyper/deephyper/issues/156. 

Summary of changes
- Updated the docstrings of `surrogate_model` and `n_jobs` in `CBO`. `n_jobs` is only used in `surrogate_model` if `surrogate_model` is one of the accepted strings (i.e. `n_jobs` is not passed to `surrogate_model` if it is a `sklearn` regressor, and the user must define it in their instance if they want a non-default value).
- Drop `surrogate_model`'s `"str"` type from the function definition of `CBO`.
- Move the `base_estimator` logic up from `_opt_kwargs`, and merge it with the type checking of `surrogate_model`. If `surrogate_model` is an accepted string, then use the `_opt_kwargs` logic for defining `base_estimator`, else if `surrogate_model` is a `sklearn` regressor then use that as the `base_estimator`, otherwise raise an error.
- Move the `n_jobs` check above the `base_estimator` check since it is used in the `_opt_kwargs` logic for `base_estimator`.
- Pass `base_estimator` as is in `_opt_kwargs`.

Similar changes are made in `DBO` where appropriate. I think `surrogate_model_kwargs` is no longer necessary to the `DBO` now, since all these can be defined in the `sklearn` regressor instance that is passable to `surrogate_model`, but I haven't made any changes related to this, since it will probably not be backwards compatible. 

I also haven't addressed the normalization point raised in the original issue, since this seems to be handled by `skopt` itself. For instance, in the `GaussianProcessRegressor` class, there is an option to `normalize_y`. Is that what you had in mind? See [here](https://github.com/scikit-optimize/scikit-optimize/blob/a2369ddbc332d16d8ff173b12404b03fea472492/skopt/learning/gaussian_process/gpr.py#L39).
