### PR TITLE
Fix: fit_surrogate CSV handling issues in DeepHyper

### DIFF
--- a/deephyper/search/hps/_cbo.py
+++ b/deephyper/search/hps/_cbo.py
@@ -562,23 +562,31 @@ class CBO(Search):
 
         return df
 
-    def fit_surrogate(self, df, context_yaml_file=None):
-
+    def fit_surrogate(self, df, context_yaml_file_or_datatypes=None):
         """Fit the surrogate model of the search from a checkpointed Dataframe.
 
         Args:
             df (str|DataFrame): a checkpoint from a previous search.
-
-        Example Usage:
-
+            context_yaml_file_or_datatypes (str|list): Context file in YAML format or list of ConfigSpace hyperparameter types.
+            
+        Example Usages:
+        
         >>> search = CBO(problem, evaluator)
-        >>> search.fit_surrogate("results.csv")
+        >>> search.fit_surrogate("results.csv")  # without context_yaml_file_or_datatypes argument
+
+        >>> search.fit_surrogate("results.csv", "config.yaml")  # with YAML file as context_yaml_file_or_datatypes argument
+
+        >>> search.fit_surrogate("results.csv", ['categorical', 'normal_int', 'uniform_float'])  # with list of types as context_yaml_file_or_datatypes argument
         """
-        if type(df) is str and df[-4:] == ".csv":
+        if isinstance(df, str) and df.endswith(".csv"):
+            # If context is a list, just set "datatypes = context_yaml_file_or_datatypes"
+            if isinstance(context_yaml_file_or_datatypes, list):
+                datatypes = context_yaml_file_or_datatypes
+
             # Check if the context yaml file is specified and exists
-            if context_yaml_file and os.path.isfile(context_yaml_file): 
+            elif context_yaml_file_or_datatypes and os.path.isfile(context_yaml_file_or_datatypes):
                 # Load YAML file
-                with open(context_yaml_file, 'r') as file:
+                with open(context_yaml_file_or_datatypes, 'r') as file:
                     data = yaml.safe_load(file)
 
                 # Extract problem hyperparameters

--- a/deephyper/search/hps/_cbo.py
+++ b/deephyper/search/hps/_cbo.py
@@ -533,32 +533,24 @@ class CBO(Search):
             raise ValueError("Provided object is not a pandas DataFrame")
 
         # Check if objective columns exist
-        if "objective" not in df.columns and not any(df.filter(regex=r"^objective_\d+$").columns):
+        if "objective" not in df.columns and not any(
+            df.filter(regex=r"^objective_\d+$").columns
+        ):
             raise ValueError("Objective column(s) missing from DataFrame")
 
         # Convert objective columns to numeric if they're not
         if "objective" in df.columns:
-            df['objective'] = pd.to_numeric(df['objective'], errors='coerce')
+            df["objective"] = pd.to_numeric(df["objective"], errors="coerce")
         else:
             for column in df.filter(regex=r"^objective_\d+$").columns:
-                df[column] = pd.to_numeric(df[column], errors='coerce')
+                df[column] = pd.to_numeric(df[column], errors="coerce")
 
         # Get rows with NaN values
         nan_rows_df = df[df.isna().any(axis=1)]
         nan_rows_count = len(nan_rows_df)
-        
+
         # Remove rows with NaN values
         df.dropna(inplace=True)
-
-        # Check and transform objective function values to ensure they can be processed with np.negative
-        try:
-            objective_values = df['objective'].tolist() if "objective" in df.columns else df.filter(regex=r"^objective_\d+$").values.tolist()
-            [np.negative(value).tolist() for value in objective_values]
-        except numpy.core._exceptions._UFuncNoLoopError:
-            problematic_values = [value for value in objective_values if not np.issubdtype(type(value), np.number)]
-            print(f"Number of problematic objective function values: {len(problematic_values)}")
-            print(f"Examples problematic objective function values: {problematic_values[:5]}")
-            raise
 
         return df
 
@@ -568,9 +560,9 @@ class CBO(Search):
         Args:
             df (str|DataFrame): a checkpoint from a previous search.
             context_yaml_file_or_datatypes (str|list): Context file in YAML format or list of ConfigSpace hyperparameter types.
-            
+
         Example Usages:
-        
+
         >>> search = CBO(problem, evaluator)
         >>> search.fit_surrogate("results.csv")  # without context_yaml_file_or_datatypes argument
 
@@ -584,51 +576,59 @@ class CBO(Search):
                 datatypes = context_yaml_file_or_datatypes
 
             # Check if the context yaml file is specified and exists
-            elif context_yaml_file_or_datatypes and os.path.isfile(context_yaml_file_or_datatypes):
+            elif context_yaml_file_or_datatypes and os.path.isfile(
+                context_yaml_file_or_datatypes
+            ):
                 # Load YAML file
-                with open(context_yaml_file_or_datatypes, 'r') as file:
+                with open(context_yaml_file_or_datatypes, "r") as file:
                     data = yaml.safe_load(file)
 
                 # Extract problem hyperparameters
-                hyperparameters = data['search']['problem']['hyperparameters']
+                hyperparameters = data["search"]["problem"]["hyperparameters"]
 
                 # Extract types
-                datatypes = [param['type'] for param in hyperparameters]
-
+                datatypes = [param["type"] for param in hyperparameters]
 
             # Read the CSV file and get the header row
-            with open(df, 'r') as f:
-                reader = csv.reader(f) 
+            with open(df, "r") as f:
+                reader = csv.reader(f)
                 header_row = next(reader)
                 num_columns = len(header_row)
-                
+
                 dtype_dict = {}
                 for name, datatype in zip(header_row, datatypes):
-                    if datatype == 'categorical':
+                    if datatype == "categorical":
                         dtype_dict[name] = str
-                    elif datatype.endswith('_int'):
+                    elif datatype.endswith("_int"):
                         dtype_dict[name] = int
-                    elif datatype.endswith('_float'):
+                    elif datatype.endswith("_float"):
                         dtype_dict[name] = float
                     else:
                         dtype_dict[name] = None  # Default: let pandas infer the type
 
                 rows_to_skip = []
                 skipped_rows = []
-                for i, row in enumerate(reader, start=1):  # Start enumeration at 1 due to header row
+                for i, row in enumerate(
+                    reader, start=1
+                ):  # Start enumeration at 1 due to header row
                     # Add rows with different number of columns, identical to header, or missing data to skip list
-                    if len(row) != num_columns or row == header_row or any(x == '' for x in row): 
+                    if (
+                        len(row) != num_columns
+                        or row == header_row
+                        or any(x == "" for x in row)
+                    ):
                         rows_to_skip.append(i)
-                        if len(skipped_rows) < 15:  # Limiting the skipped_rows examples to 15
+                        if (
+                            len(skipped_rows) < 15
+                        ):  # Limiting the skipped_rows examples to 15
                             skipped_rows.append(row)
 
             # Convert skipped_rows to a DataFrame for better visualisation and print it
             skipped_rows_df = pd.DataFrame(skipped_rows, columns=header_row)
-            #print("Row numbers to be skipped: ", rows_to_skip)
-            #print("Examples of skipped rows: ")
-            #with pd.option_context('display.max_columns', None):
+            # print("Row numbers to be skipped: ", rows_to_skip)
+            # print("Examples of skipped rows: ")
+            # with pd.option_context('display.max_columns', None):
             #    print(skipped_rows_df)
-
 
             # Read the CSV file again, skipping problematic rows
             df = pd.read_csv(df, skiprows=rows_to_skip, dtype=dtype_dict)

--- a/deephyper/search/hps/_cbo.py
+++ b/deephyper/search/hps/_cbo.py
@@ -571,22 +571,16 @@ class CBO(Search):
         >>> search.fit_surrogate("results.csv", ['categorical', 'normal_int', 'uniform_float'])  # with list of types as context_yaml_file_or_datatypes argument
         """
         if isinstance(df, str) and df.endswith(".csv"):
-            # If context is a list, just set "datatypes = context_yaml_file_or_datatypes"
             if isinstance(context_yaml_file_or_datatypes, list):
                 datatypes = context_yaml_file_or_datatypes
 
-            # Check if the context yaml file is specified and exists
             elif context_yaml_file_or_datatypes and os.path.isfile(
                 context_yaml_file_or_datatypes
             ):
-                # Load YAML file
                 with open(context_yaml_file_or_datatypes, "r") as file:
                     data = yaml.safe_load(file)
-
-                # Extract problem hyperparameters
                 hyperparameters = data["search"]["problem"]["hyperparameters"]
-
-                # Extract types
+                # Extract ConfigSpace hyperparameter types
                 datatypes = [param["type"] for param in hyperparameters]
 
             # Read the CSV file and get the header row

--- a/deephyper/search/hps/_cbo.py
+++ b/deephyper/search/hps/_cbo.py
@@ -564,6 +564,8 @@ class CBO(Search):
         Example Usages:
 
         >>> search = CBO(problem, evaluator)
+        >>> search.fit_surrogate(df) # with the checkpoint as a dataframe
+
         >>> search.fit_surrogate("results.csv")  # without context_yaml_file_or_datatypes argument
 
         >>> search.fit_surrogate("results.csv", "config.yaml")  # with YAML file as context_yaml_file_or_datatypes argument

--- a/deephyper/skopt/utils.py
+++ b/deephyper/skopt/utils.py
@@ -195,10 +195,17 @@ def is_2Dlistlike(x):
 
 def check_x_in_space(x, space):
     if is_2Dlistlike(x):
-        if not np.all([p in space for p in x]):
-            raise ValueError("Not all points are within the bounds of" " the space.")
-        if any([len(p) != len(space.dimensions) for p in x]):
-            raise ValueError("Not all points have the same dimensions as" " the space.")
+        for p in x:
+            if p not in space:
+                raise ValueError(
+                    "Point (%s) is not within the bounds of"
+                    " the space (%s)." % (p, space.bounds)
+                )
+            if len(p) != len(space.dimensions):
+                raise ValueError(
+                    "Dimensions of point (%s) and space (%s) do not match"
+                    % (p, space.bounds)
+                )
     elif is_listlike(x):
         print(x)
         if x not in space:


### PR DESCRIPTION
This pull request addresses issues described in bug #186 related to the `fit_surrogate` method in DeepHyper. The specific issues addressed include:

1. Categorical hyperparameters, represented as numbers, are now correctly read as categorical values rather than numeric values, provided that a list of hyperparameter ConfigSpace types or the context YAML filename is passed to `fit_surrogate` as an optional argument.
2. Rows with missing values or incorrect number of columns are properly handled now to avoid inaccurate modeling or data misalignment.
3. When multiple results CSV files are concatenated, duplicate header rows are now ignored to prevent incorrect data ingestion.

With these fixes, users can expect `fit_surrogate` to correctly interpret and handle their CSV files, thereby improving the reliability and accuracy of the method.

Please review the changes and let me know if there are any questions or concerns.

Resolves #186