### PR TITLE
Add uv installation page in documentation

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -12,6 +12,7 @@ DeepHyper is a Python package containing different modules that can be installed
    jupyter <jupyter>
    pip (default) <pip>
    spack <spack>
+   uv <uv>
 
 .. toctree::
    :maxdepth: 1

--- a/docs/install/pip.rst
+++ b/docs/install/pip.rst
@@ -15,15 +15,15 @@ DeepHyper is available on `PyPI <https://pypi.org/project/deephyper/>`_ and can 
     $ pip install "deephyper[core]" # <=> "deephyper[sdv,tf-keras2,jax-cpu,torch]"
     
     $ # Isolated features
-    $ pip install "deephyper" # Install Hyperparameter Optimization (HPO).
-    $ pip install "deephyper[sdv]" # Install SDV for HPO (Transfer Learning).
-    $ pip install "deephyper[jax-cpu]" # Install JAX with CPU support for Learning Curve Extrapolation Stopper.
-    $ pip install "deephyper[jax-cuda]" # Install JAX with GPU (cuda) support for Learning Curve Extrapolation Stopper.
-    $ pip install "deephyper[tf-keras2]" # Install DeepHyper with Tensorflow/Keras2 support.
-    $ pip install "deephyper[torch]" # Install DeepHyper with Pytorch support.
+    $ pip install "deephyper"             # install hyperparameter optimization (HPO)
+    $ pip install "deephyper[sdv]"        # install SDV for HPO (transfer learning)
+    $ pip install "deephyper[jax-cpu]"    # install JAX with CPU support for Learning Curve Extrapolation Stopper
+    $ pip install "deephyper[jax-cuda]"   # install JAX with GPU (Cuda) support for Learning Curve Extrapolation Stopper
+    $ pip install "deephyper[tf-keras2]"  # install with Tensorflow/Keras2 support
+    $ pip install "deephyper[torch]"      # install with Pytorch support
     
     $ # For developers (Tests, Documentation, etc...)
-    $ pip install "deephyper[dev]" # Install Developer Stack (tests, documentation, etc...)
+    $ pip install "deephyper[dev]"        # install developer stack (tests, documentation, etc.)
 
 
 In Bayesian optimization, the Mondrian Forest surrogate model can be used. This model provides better uncertainty estimates used in the acquisition function. To install the Mondrian Forest surrogate model, you need to install the modified ``scikit-garden`` package from our repository. This package is not available on PyPI but can be installed through ``pip`` from the GitHub repository:
@@ -40,10 +40,10 @@ DeepHyper supports distributed computation with different backends. ``MPI`` demo
 
 .. code-block:: console
 
-    $ pip install "deephyper[mpi]" # Install python bindings for MPI.
-    $ pip install "deephyper[ray]" # Install Ray.
-    $ pip install "deephyper[redis]" # Install Redis Client.
-    $ pip install "deephyper[redis-hiredis]" # Install Redis Client with Hiredis for better performance.
+    $ pip install "deephyper[mpi]"            # install python bindings for MPI
+    $ pip install "deephyper[ray]"            # install Ray
+    $ pip install "deephyper[redis]"          # install Redis client
+    $ pip install "deephyper[redis-hiredis]"  # install Redis client with Hiredis for better performance
 
 
 Redis

--- a/docs/install/uv.rst
+++ b/docs/install/uv.rst
@@ -1,0 +1,16 @@
+Install with uv
+===============
+
+DeepHyper can also be installed with the `uv tool <https://docs.astral.sh/uv/>`_ which is a fast Python package and project manager. The uv commands shown below will create a Python project with a virtual environment that contains the deephyper package. See the uv documentation for more information about working with Python using the uv tool.
+
+.. code-block:: console
+
+   $ uv init myproject
+   $ cd myproject
+   $ uv add deephyper
+
+Below is a demo of creating a Python project with uv, adding the deephyper package to the project, then running Python in the project's virtual environment to import deephyper and get its version number.
+
+.. raw:: html
+
+   <script src=https://asciinema.org/a/2jW3aaEcn6RSwOahyGSS9rFWd.js id=asciicast-2jW3aaEcn6RSwOahyGSS9rFWd async=true></script>


### PR DESCRIPTION
This adds a documentation page about using uv to install the deephyper package into a Python project. A terminal session demo of this process is also included in the page.