### PR TITLE
Add section in docs for facility guides

### DIFF
--- a/docs/facility/alcf/index.rst
+++ b/docs/facility/alcf/index.rst
@@ -1,0 +1,11 @@
+Argonne Leadership Computing Facility (ALCF)
+============================================
+
+.. toctree::
+   :titlesonly:
+   :numbered:
+
+   theta
+   theta-gpu-ray
+   theta-gpu-mpi
+   theta-gpu-jupyter

--- a/docs/facility/alcf/theta-gpu-jupyter.rst
+++ b/docs/facility/alcf/theta-gpu-jupyter.rst
@@ -1,0 +1,55 @@
+.. _tutorial-alcf-04:
+
+Execution on the ThetaGPU supercomputer (within a Jupyter notebook)
+*******************************************************************
+
+In this tutorial we are going to learn how to run an interactive Jupyter notebook on the **ThetaGPU** supercomputer at the ALCF using Ray. `ThetaGPU <https://www.alcf.anl.gov/support-center/theta/theta-thetagpu-overview>`_ is a 3.9 petaflops system based on NVIDIA DGX A100.
+
+After logging in Theta:
+
+1. From ``thetaloginX``, start an interactive job (**note** which ``thetagpuXX`` node you get placed onto will vary) by replacing your ``$PROJECT_NAME`` and ``$QUEUE_NAME`` (e.g. of available queues are ``full-node`` and ``single-gpu``):
+
+.. code-block:: console
+
+    (thetalogin5) $ qsub -I -A $PROJECT_NAME -n 1 -q $QUEUE_NAME -t 60
+    Job routed to queue "full-node".
+    Wait for job 10003623 to start...
+    Opening interactive session to thetagpu21
+
+2. Wait for the interactive session to start. Then, from the ThetaGPU compute node (`thetagpuXX`), execute the following commands to initialize your DeepHyper environment (adapt to your needs):
+
+.. code-block:: console
+
+    $ . /etc/profile
+    $ module load conda/2022-07-01
+    $ conda activate $CONDA_ENV_PATH
+
+3. Then, start the Jupyter notebook server:
+
+.. code-block:: console
+
+    $ jupyter notebook &
+
+.. note::
+
+    In the case of a multi-GPUs node, it is possible that the Jupyter notebook process will lock one of the available GPUs. Therefore, launch the notebook with the following command instead:
+
+    .. code-block:: console
+
+        CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6 jupyter notebook &
+
+4. Take note of the hostname of the current compute node (e.g. ``thetagpuXX``):
+
+.. code-block:: console
+
+    echo $HOSTNAME
+
+5. Leave the interactive session running and open a new terminal window on your local machine.
+
+6. In the new terminal window, execute the SSH command to link the local port to the ThetaGPU compute node after replacing with you ``$USERNAME`` and corresponding ``thetagpuXX``:
+
+.. code-block:: console
+
+    $ ssh -tt -L 8888:localhost:8888 $USERNAME@theta.alcf.anl.gov "ssh -L 8888:localhost:8888 thetagpuXX"
+
+7. Open the Jupyter URL (`http:localhost:8888/?token=....`) in a local browser. This URL was printed out at step 4.

--- a/docs/facility/alcf/theta-gpu-mpi.rst
+++ b/docs/facility/alcf/theta-gpu-mpi.rst
@@ -1,0 +1,292 @@
+.. _tutorial-alcf-03:
+
+Execution on the ThetaGPU supercomputer (with MPI)
+**************************************************
+
+In this tutorial we are going to learn how to use DeepHyper on the **ThetaGPU** supercomputer at the ALCF using MPI. `ThetaGPU <https://www.alcf.anl.gov/support-center/theta/theta-thetagpu-overview>`_ is a 3.9 petaflops system based on NVIDIA DGX A100.
+
+Submission Script
+=================
+
+This section of the tutorial will show you how to submit script to the COBALT scheduler of ThetaGPU. To execute DeepHyper on ThetaGPU with a submission script it is required to:
+
+1. Define a Bash script to initialize the environment (e.g., load a module, activate a conda environment).
+2. Define an execution script, which will call the bash script defined in 1. and launch the python script using ``mpirun``.
+
+Start by creating a script named ``activate-dhenv.sh`` to initialize your environment. Replace the ``$CONDA_ENV_PATH`` by your personnal conda installation (e.g., it can be replaced by ``base`` if no virtual environment is used):
+
+
+.. code-block:: bash
+    :caption: **file**: ``activate-dhenv.sh``
+
+    #!/bin/bash
+
+    # Necessary for Bash shells
+    . /etc/profile
+
+    # Tensorflow optimized for A100 with CUDA 11
+    module load conda/2022-07-01
+
+    # Activate conda env
+    conda activate $CONDA_ENV_PATH
+
+.. tip::
+
+    This ``activate-dhenv`` script can be very useful to tailor the execution's environment to your needs. Here are a few tips that can be useful:
+
+    - To activate XLA optimized compilation add ``export TF_XLA_FLAGS=--tf_xla_enable_xla_devices``
+    - To change the log level of Tensorflow add ``export TF_CPP_MIN_LOG_LEVEL=3``
+
+Then create a new file named ``job-deephyper.sh`` and make it executable. It will correspond to your submission script.
+
+.. code-block:: bash
+
+    $ touch job-deephyper.sh && chmod +x job-deephyper.sh
+
+.. code-block:: bash
+    :caption: **file**: ``job-deephyper.sh``
+
+    #!/bin/bash
+    #COBALT -q full-node
+    #COBALT -n 2
+    #COBALT -t 20
+    #COBALT -A $PROJECT_NAME
+    #COBALT --attrs filesystems=home,grand,eagle,theta-fs0
+
+    # User Configuration
+    INIT_SCRIPT=$PWD/activate-dhenv.sh
+    COBALT_JOBSIZE=2
+    RANKS_PER_NODE=8
+
+    # Initialization of environment
+    source $INIT_SCRIPT
+
+    mpirun -x LD_LIBRARY_PATH -x PYTHONPATH -x PATH -n $(( $COBALT_JOBSIZE * $RANKS_PER_NODE )) -N $RANKS_PER_NODE --hostfile $COBALT_NODEFILE python myscript.py
+
+.. note::
+
+    About the *COBALT* directives :
+
+    .. code-block:: bash
+
+        #COBALT -q full-node
+
+    The queue your job will be submitted to. For ThetaGPU it can either be ``single-gpu``, ``full-node``, or ``bigmem`` ; you can find here the `specificities of these queues <https://www.alcf.anl.gov/support-center/theta-gpu-nodes/job-and-queue-scheduling-thetagpu#gpu-queues>`_.
+
+    .. code-block:: bash
+
+        #COBALT -n 2
+
+    The number of nodes your job will be submitted to.
+
+    .. code-block:: bash
+
+        #COBALT -t 20
+
+    The duration of the job submission, in minutes.
+
+    .. code-block:: bash
+
+        #COBALT -A $PROJECT_NAME
+
+    Your current project, e-g ``#COBALT -A datascience``:
+
+    .. code-block:: bash
+
+        #COBALT --attrs filesystems=home,grand,eagle,theta-fs0
+
+    The filesystems your application should have access to, DeepHyper only requires ``home`` and ``theta-fs0``, and it is unnecessary to let in this list a filesystem your application (and DeepHyper) doesn't need.
+
+.. note::
+
+    .. code-block:: bash
+
+        COBALT_JOBSIZE=2
+        RANKS_PER_NODE=8
+
+    ``COBALT_JOBSIZE`` and ``RANKS_PER_NODE`` correspond respectively to the number of nodes allocated and number of process per node. Unlike ``Theta`` on which ``COBALT_JOBSIZE`` is automatically instanciated to the correct value, on ``ThetaGPU`` it has to be done by hand : ``COBALT_JOBSIZE`` should always correspond to the number of nodes you submitted your application to (the number after ``#COBALT -n``). e-g if you were to happen to have a ``#COBALT -n 4`` you should have ``COBALT_JOBSIZE=4``.
+
+Adapt the executed Python application depending on your needs. Here is an application example of ``CBO`` using the ``mpi_comm`` evaluator:
+
+.. code-block:: python
+    :caption: **file**: ``myscript.py``
+
+    import pathlib
+    import os
+
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
+    import mpi4py
+
+    mpi4py.rc.initialize = False
+    mpi4py.rc.threads = True
+    mpi4py.rc.thread_level = "multiple"
+    mpi4py.rc.recv_mprobe = False
+
+    from deephyper.evaluator import Evaluator
+    from deephyper.hpo import CBO
+
+    from mpi4py import MPI
+
+    if not MPI.Is_initialized():
+        MPI.Init_thread()
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    from deephyper.hpo import HpProblem
+
+
+    hp_problem = HpProblem()
+    hp_problem.add_hyperparameter((-10.0, 10.0), "x")
+
+    def run(config):
+        return - config["x"]**2
+
+    timeout = 10
+    search_log_dir = "search_log/"
+    pathlib.Path(search_log_dir).mkdir(parents=False, exist_ok=True)
+
+    if rank == 0:
+        # Evaluator creation
+        print("Creation of the Evaluator...")
+
+    with Evaluator.create(
+        run,
+        method="mpicomm",
+    ) as evaluator:
+        if evaluator is not None:
+            print(f"Creation of the Evaluator done with {evaluator.num_workers} worker(s)")
+
+            # Search creation
+            print("Creation of the search instance...")
+            search = CBO(
+                hp_problem,
+                evaluator,
+            )
+            print("Creation of the search done")
+
+            # Search execution
+            print("Starting the search...")
+            results = search.search(timeout=timeout)
+            print("Search is done")
+
+            results.to_csv(os.path.join(search_log_dir, f"results.csv"))
+
+.. note::
+
+    If you are using tensorflow, you might want to add this snippet to your script in order to ensure that each worker is restricted to its own gpu (and doesn't access other workers memory):
+
+    .. code-block:: python
+
+        from mpi4py import MPI
+        comm = MPI.COMM_WORLD
+        rank = comm.Get_rank()
+        gpu_local_idx = rank % gpu_per_node
+        node = int(rank / gpu_per_node)
+
+        import tensorflow as tf
+        gpus = tf.config.list_physical_devices("GPU")
+        if gpus:
+            # Restrict TensorFlow to only use the first GPU
+            try:
+                tf.config.set_visible_devices(gpus[gpu_local_idx], "GPU")
+                tf.config.experimental.set_memory_growth(gpus[gpu_local_idx], True)
+                logical_gpus = tf.config.list_logical_devices("GPU")
+                logging.info(f"[r={rank}]: {len(gpus)} Physical GPUs, {len(logical_gpus)} Logical GPU")
+            except RuntimeError as e:
+                # Visible devices must be set before GPUs have been initialized
+                logging.info(f"{e}")
+
+    With ``gpu_per_node`` being equal to the ``RANKS_PER_NODE`` value specified in ``job-deephyper.sh``.
+
+.. note::
+    If you are using PyTorch, most of the code from myscript.py starts off similar:
+
+    .. code-block:: python
+
+        import mpi4py
+        from mpi4py import MPI
+
+        mpi4py.rc.initialize = False
+        mpi4py.rc.threads = True
+        mpi4py.rc.thread_level = "multiple"
+
+        if not MPI.Is_initialized():
+            MPI.Init_thread()
+
+        comm = MPI.COMM_WORLD
+        rank = comm.Get_rank()
+
+    In order to properly use PyTorch while maintaining flexibility, defining the device that the evaluations will be sent to is very important. As all GPUs initially run the same script, they will need their rank defined under the run function. We define the three possible scenarios when running on any given machine:
+
+    .. code-block:: python
+
+        if is_gpu_available and n_gpus > 1:
+            device = torch.device("cuda", rank)
+            print("Running on GPU ", rank)
+        elif is_gpu_available and n_gpus == 1:
+            device = torch.device("cuda", 0)
+            print("Running on the GPU")
+        else:
+            device = torch.device("cpu")
+            print("Running on the CPU")
+
+    After defining the black box function, we compute the result on the assigned GPU. Note that while in this instance the run function returns a ``objective.item()``, all that is needed is a valid float or integer. A portion of myscript.py should resemble something of the following:
+
+    .. code-block:: python
+
+        def run(config: dict):
+            ### Change as needed
+            if is_gpu_available and n_gpus > 1:
+                device = torch.device("cuda", rank)
+                print("Running on GPU ", rank)
+            elif is_gpu_available and n_gpus == 1:
+                device = torch.device("cuda", 0)
+                print("Running on the GPU")
+            else:
+                device = torch.device("cpu")
+                print("Running on the CPU")
+            objective = torch.tensor([-config["x"]**2]).to(device)
+
+            return objective.item()
+
+        if __name__ == "__main__":
+            is_gpu_available = torch.cuda.is_available()
+            n_gpus = torch.cuda.device_count() if is_gpu_available else 0
+
+
+            hp_problem = HpProblem()
+            hp_problem.add_hyperparameter((-10.0, 10.0), "x")
+
+            if rank == 0:
+            # Evaluator creation
+            print("Creation of the Evaluator...")
+
+            with Evaluator.create(
+                run,
+                method="mpicomm",
+            ) as evaluator:
+                if evaluator is not None:
+                    print(f"Creation of the Evaluator done with {evaluator.num_workers} worker(s)")
+
+                    # Search creation
+                    print("Creation of the search instance...")
+                    search = CBO(
+                        hp_problem,
+                        evaluator,
+                    )
+                    print("Creation of the search done")
+
+                    # Search execution
+                    print("Starting the search...")
+                    results = search.search(timeout=timeout)
+                    print("Search is done")
+
+                    results.to_csv(os.path.join(search_log_dir, f"results.csv"))
+
+Finally, submit the script using :
+
+.. code-block:: bash
+
+    qsub-gpu job-deephyper.sh

--- a/docs/facility/alcf/theta-gpu-ray.rst
+++ b/docs/facility/alcf/theta-gpu-ray.rst
@@ -1,0 +1,209 @@
+.. _tutorial-alcf-02:
+
+Execution on the ThetaGPU supercomputer (with Ray)
+**************************************************
+
+In this tutorial we are going to learn how to use DeepHyper on the **ThetaGPU** supercomputer at the ALCF using Ray. `ThetaGPU <https://www.alcf.anl.gov/support-center/theta/theta-thetagpu-overview>`_ is a 3.9 petaflops system based on NVIDIA DGX A100.
+
+Submission Script
+=================
+
+This section of the tutorial will show you how to submit script to the COBALT scheduler of ThetaGPU. To execute DeepHyper on ThetaGPU with a submission script it is required to:
+
+1. Define a Bash script to initialize the environment (e.g., load a module, activate a conda environment).
+2. Define a script composed of 3 steps: (1) launch a Ray cluster on available ressources, (2) execute a Python application which connects to the Ray cluster, and (3) stop the Ray cluster.
+
+Start by creating a script named ``activate-dhenv.sh`` to initialize your environment. It will be used to initialize each used compute node. Replace the ``$CONDA_ENV_PATH`` by your personnal conda installation (e.g., it can be replaced by ``base`` if no virtual environment is used):
+
+
+.. code-block:: bash
+    :caption: **file**: ``activate-dhenv.sh``
+
+    #!/bin/bash
+
+    # Necessary for Bash shells
+    . /etc/profile
+
+    # Tensorflow optimized for A100 with CUDA 11
+    module load conda/2022-07-01
+
+    # Activate conda env
+    conda activate $CONDA_ENV_PATH
+
+.. tip::
+
+    This ``activate-dhenv`` script can be very useful to tailor the execution's environment to your needs. Here are a few tips that can be useful:
+
+    - To activate XLA optimized compilation add ``export TF_XLA_FLAGS=--tf_xla_enable_xla_devices``
+    - To change the log level of Tensorflow add ``export TF_CPP_MIN_LOG_LEVEL=3``
+
+
+Then create a new file named ``job-deephyper.sh`` and make it executable. It will correspond to your submission script.
+
+.. code-block:: bash
+
+    $ touch job-deephyper.sh && chmod +x job-deephyper.sh
+
+Add the following content:
+
+.. code-block:: bash
+    :caption: **file**: ``job-deephyper.sh``
+
+    #!/bin/bash
+    #COBALT -q full-node
+    #COBALT -n 2
+    #COBALT -t 20
+    #COBALT -A $PROJECT_NAME
+    #COBALT --attrs filesystems=home,grand,eagle,theta-fs0
+
+    # User Configuration
+    EXP_DIR=$PWD
+    INIT_SCRIPT=$PWD/activate-dhenv.sh
+    CPUS_PER_NODE=8
+    GPUS_PER_NODE=8
+
+    # Initialization of environment
+    source $INIT_SCRIPT
+
+    # Getting the node names
+    mapfile -t nodes_array -d '\n' < $COBALT_NODEFILE
+
+    head_node=${nodes_array[0]}
+    head_node_ip=$(dig $head_node a +short | awk 'FNR==2')
+
+    # Starting the Ray Head Node
+    port=6379
+    ip_head=$head_node_ip:$port
+    export ip_head
+    echo "IP Head: $ip_head"
+
+    echo "Starting HEAD at $head_node"
+    ssh -tt $head_node_ip "source $INIT_SCRIPT; cd $EXP_DIR; \
+        ray start --head --node-ip-address=$head_node_ip --port=$port \
+        --num-cpus $CPUS_PER_NODE --num-gpus $GPUS_PER_NODE --block" &
+
+    # Optional, though may be useful in certain versions of Ray < 1.0.
+    sleep 10
+
+    # Number of nodes other than the head node
+    nodes_num=$((${#nodes_array[*]} - 1))
+    echo "$nodes_num nodes"
+
+    for ((i = 1; i <= nodes_num; i++)); do
+        node_i=${nodes_array[$i]}
+        node_i_ip=$(dig $node_i a +short | awk 'FNR==1')
+        echo "Starting WORKER $i at $node_i with ip=$node_i_ip"
+        ssh -tt $node_i_ip "source $INIT_SCRIPT; cd $EXP_DIR; \
+            ray start --address $ip_head \
+            --num-cpus $CPUS_PER_NODE --num-gpus $GPUS_PER_NODE --block" &
+        sleep 5
+    done
+
+    # Check the status of the Ray cluster
+    ssh -tt $head_node_ip "source $INIT_SCRIPT && ray status"
+
+    # Run the search
+    ssh -tt $head_node_ip "source $INIT_SCRIPT && cd $EXP_DIR && python myscript.py"
+
+    # Stop de Ray cluster
+    ssh -tt $head_node_ip "source $INIT_SCRIPT && ray stop"
+
+.. note::
+
+    About the *COBALT* directives :
+
+    .. code-block:: bash
+
+        #COBALT -q full-node
+
+    The queue your job will be submitted to. For ThetaGPU it can either be ``single-gpu``, ``full-node``, or ``bigmem`` ; you can find here the `specificities of these queues <https://www.alcf.anl.gov/support-center/theta-gpu-nodes/job-and-queue-scheduling-thetagpu#gpu-queues>`_.
+
+    .. code-block:: bash
+
+        #COBALT -n 2
+
+    The number of nodes your job will be submitted to.
+
+    .. code-block:: bash
+
+        #COBALT -t 20
+
+    The duration of the job submission, in minutes.
+
+    .. code-block:: bash
+
+        #COBALT -A $PROJECT_NAME
+
+    Your current project, e-g ``#COBALT -A datascience``:
+
+    .. code-block:: bash
+
+        #COBALT --attrs filesystems=home,grand,eagle,theta-fs0
+
+    The filesystems your application should have access to, DeepHyper only requires ``home`` and ``theta-fs0``, and it is unnecessary to let in this list a filesystem your application (and DeepHyper) doesn't need.
+
+Adapt the executed Python application depending on your needs. Here is an application example of ``CBO`` using the ``ray`` evaluator:
+
+.. code-block:: python
+    :caption: **file**: ``myscript.py``
+
+    import pathlib
+    import os
+
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+
+    import numpy as np
+
+    from deephyper.evaluator import Evaluator
+    from deephyper.hpo import CBO
+    from deephyper.evaluator.callback import ProfilingCallback
+
+    from deephyper.hpo import HpProblem
+
+
+    hp_problem = HpProblem()
+    hp_problem.add_hyperparameter((-10.0, 10.0), "x")
+
+    def run(config):
+        return - config["x"]**2
+
+    timeout = 10
+    search_log_dir = "search_log/"
+    pathlib.Path(search_log_dir).mkdir(parents=False, exist_ok=True)
+
+    # Evaluator creation
+    print("Creation of the Evaluator...")
+    evaluator = Evaluator.create(
+        run,
+        method="ray",
+        method_kwargs={
+            "adress": "auto",
+            "num_gpus_per_task": 1,
+        }
+    )
+    print(f"Creation of the Evaluator done with {evaluator.num_workers} worker(s)")
+
+    # Search creation
+    print("Creation of the search instance...")
+    search = CBO(
+        hp_problem,
+        evaluator,
+    )
+    print("Creation of the search done")
+
+    # Search execution
+    print("Starting the search...")
+    results = search.search(timeout=timeout)
+    print("Search is done")
+
+    results.to_csv(os.path.join(search_log_dir, f"results.csv"))
+
+Finally, submit the script using:
+
+.. code-block:: bash
+
+    qsub-gpu job-deephyper.sh
+
+.. note::
+
+    The ``ssh -tt $head_node_ip "source $INIT_SCRIPT && ray status"`` command is used to check the good initialization of the Ray cluster. Once the job starts running, check the ``*.output`` file and verify that the number of detected GPUs is correct.

--- a/docs/facility/alcf/theta.rst
+++ b/docs/facility/alcf/theta.rst
@@ -1,0 +1,267 @@
+.. _tutorial-alcf-01:
+
+Execution on the Theta supercomputer
+************************************
+
+In this tutorial we are going to learn how to use DeepHyper on the **Theta** supercomputer at the ALCF. `Theta <https://www.alcf.anl.gov/support-center/theta/theta-thetagpu-overview>`_ is  a Cray XC40, 11.7 petaflops system based on Intel® Xeon Phi processor. It is composed of:
+
+1. Login nodes ``thetalogin*``
+2. Head nodes ``thetamom*``
+3. Compute nodes ``nid*``
+
+When logging in **Theta** you are located on a **login node**. From this node you can set up your environment such as downloading your data or installing the software you will use for your experimentations. Then, you will setup an experiment using DeepHyper and finally submit an allocation request with the ``qsub`` command line to execute your code on the compute nodes. Once the allocation starts you will be located on a **head node** from which you can access compute nodes using MPI (e.g., with the ``aprun`` command line) or using SSH. However, using SSH requires a specific arguments to be present in your allocation request otherwise it will be blocked by the system.
+
+When using DeepHyper, one can use two different strategies to distribute the computation of evaluations on the supercomputer:
+
+1. :ref:`theta-n-evaluation-per-1-node`: many evaluations can be launched in parallel but each of them only uses the ressources of at most one node (e.g., one neural network training per node).
+2. :ref:`theta-1-evaluation-per-n-node`: many evaluations can be launched in parallel and each of them can use the ressources of multiple nodes.
+
+.. admonition:: About the Storage/File Systems
+    :class: dropdown, important
+
+    It is important to run DeepHyper from the appropriate storage space because some features can generate a consequante quantity of data such as model checkpointing. The storage spaces available at the ALCF are:
+
+    - ``/lus/grand/projects/``
+    - ``/lus/eagle/projects/``
+    - ``/lus/theta-fs0/projects/``
+
+    For more details refer to `ALCF Documentation <https://www.alcf.anl.gov/support-center/theta/theta-file-systems>`_.
+
+
+Submission Script
+=================
+
+.. _theta-n-evaluation-per-1-node:
+
+N-evaluation per 1-node
+-----------------------
+
+In this strategy, ``N``-evaluations can be launched per available compute node. Therefore, each evaluation uses the ressources of at most one node. For example, you can train one neural network per node, or two neural networks per node. In this case, we will (1) start by launching a Ray cluster accross all available compute nodes, then we will (2) execute the search on one of them and send tasks to previously instanciated workers.
+
+Let us start by defining a toy hyperparameter search. Create a script named ``myscript.py`` and add the following content in it:
+
+.. code-block:: python
+
+    from deephyper.hpo import HpProblem
+
+    # define the run-function to evaluation a given hyperparameter configuration
+    # here we simply want to maximise a polynomial function
+    def run(config: dict):
+        return -config["x"]**2
+
+    # define the variable(s) you want to optimize
+    problem = HpProblem()
+    problem.add_hyperparameter((-10.0, 10.0), "x")
+
+Then, it is required to define a shell script which will initialize the environment of each compute node. One way to initialize your environment could be to use the ``~/.bashrc`` or ``~/.bash_profile`` which are called at the beginning of each session. However, if you want to have different installations depending on your experimentations it is preferable to avoid activating globally each installation but instead activate them only when necessary. To that end, we will create the ``init-dh-environment.sh`` script which will be called to initialize each compute node:
+
+.. code-block:: console
+
+    $ touch init-dh-environment.sh && chmod +x init-dh-environment.sh
+
+Once created and executable you can add the following content in it (e.g. ``vim init-dh-environment.sh``) and do not forget to adapt the ``$PROJECT_NAME`` with your project's allocation:
+
+.. code-block:: bash
+    :caption: **file**: ``init-dh-environment.sh``
+
+    #!/bin/bash
+
+    export TF_CPP_MIN_LOG_LEVEL=3
+    export TF_XLA_FLAGS=--tf_xla_enable_xla_devices
+
+    module load miniconda-3
+
+    # Activate installed conda environment with DeepHyper
+    conda activate $PATH_TO_CONDA_WITH_DEEPHYPER
+
+    # We had the directory where "myscript.py" is located to be able
+    # to access it during the search
+    export PYTHONPATH=$MYSCRIPT_DIR:$PYTHONPATH
+
+Adapt the two variables ``$PATH_TO_CONDA_WITH_DEEPHYPER`` and ``$MYSCRIPT_DIR``. Once the ``init-dh-environment.sh`` is created we need to define a submission script. The goal of this script is to (1) request a given amount of ressources, (2) launch a Ray cluster accross all compute nodes, (3) execute a DeepHyper task which distribute the computation on the Ray workers. Create a folder ``exp/`` where to store your experiments. Then create a script named ``deephyper-job.qsub``:
+
+.. code-block:: console
+
+    $ mkdir exp && cd exp/
+    $ touch deephyper-job.qsub && chmod +x deephyper-job.qsub
+
+Then add the following content to ``deephyper-job.qsub``:
+
+.. code-block:: bash
+
+    #!/bin/bash
+    #COBALT -A $PROJECT_NAME
+    #COBALT -n 2
+    #COBALT -q debug-flat-quad
+    #COBALT -t 60
+    #COBALT --attrs enable_ssh=1
+
+    # User Configuration
+    EXP_DIR=$PWD
+    INIT_SCRIPT=$PWD/../init-dh-environment.sh
+    CPUS_PER_NODE=2
+
+    # Initialize environment
+    source $INIT_SCRIPT
+
+    # Getting the node names
+    nodes_array=($(python -m deephyper.core.cli._nodelist theta $COBALT_PARTNAME | grep -P '\[.*\]' | tr -d '[],'))
+
+    head_node=${nodes_array[0]}
+    head_node_ip=$(eval "getent hosts $head_node"| awk {'print $1'})
+
+    # Starting the Ray Head Node
+    port=6379
+    ip_head=$head_node_ip:$port
+    export ip_head
+    echo "IP Head: $ip_head"
+
+    echo "Starting HEAD at $head_node"
+    ssh -tt $head_node_ip "source $INIT_SCRIPT; cd $EXP_DIR; \
+        ray start --head --node-ip-address=$head_node_ip --port=$port \
+        --num-cpus $CPUS_PER_NODE --block" &
+
+    # optional, though may be useful in certain versions of Ray < 1.0.
+    sleep 10
+
+    # number of nodes other than the head node
+    worker_num=$((${#nodes_array[*]} - 1))
+    echo "$worker_num workers"
+
+    for ((i = 1; i <= worker_num; i++)); do
+        node_i=${nodes_array[$i]}
+        node_i_ip=$(eval "getent hosts $node_i"| awk {'print $1'})
+        echo "Starting WORKER $i at $node_i with ip=$node_i_ip"
+        ssh -tt $node_i_ip "source $INIT_SCRIPT; cd $EXP_DIR; \
+            ray start --address $ip_head \
+            --num-cpus $CPUS_PER_NODE --block" &
+        sleep 5
+    done
+
+    # Execute the DeepHyper Task
+    # Here the task is an hyperparameter search using the DeepHyper CLI
+    # However it is also possible to call a Python script using different
+    # Features from DeepHyper (see following notes)
+    ssh -tt $head_node_ip "source $INIT_SCRIPT && cd $EXP_DIR && \
+        deephyper hps ambs \
+        --problem myscript.problem \
+        --evaluator ray \
+        --run-function myscript.run \
+        --ray-address auto \
+        --ray-num-cpus-per-task 1"
+
+
+.. warning::
+
+    The ``#COBALT --attrs enable_ssh=1`` is crucial otherwise ``ssh`` calls will be blocked by the system.
+
+    Don't forget to adapt the ``COBALT`` variables to your needs:
+
+    .. code-block:: console
+
+            #COBALT -A $PROJECT_NAME
+            #COBALT -n 2
+            #COBALT -q debug-flat-quad
+            #COBALT -t 60
+
+.. tip::
+
+    The different ``#COBALT`` arguments can also be passed through the command line:
+
+    .. code-block:: console
+
+        qsub -n 2 -q debug-flat-quad -t 60 -A $PROJECT_NAME \
+            --attrs enable_ssh=1 \
+            deephyper-job.qsub
+
+
+.. admonition:: Use a Python script instead of DeepHyper CLI
+    :class: dropdown
+
+    Instead of calling ``deephyper hps ambs`` in ``deephyper-job.qsub`` it is possible to call a custom Python script with the following content:
+
+    .. code-block:: python
+        :caption: **file**: ``myscript.py``
+
+        def run(hp):
+            return hp["x"]
+
+        if __name__ == "__main__":
+            import os
+            from deephyper.hpo import HpProblem
+            from deephyper.hpo import CBO
+            from deephyper.evaluator.evaluate import Evaluator
+
+            problem = HpProblem()
+            problem.add_hyperparameter((0.0, 10.0), "x")
+
+            evaluator = Evaluator.create(
+                run, method="ray", method_kwargs={
+                    "address": "auto"
+                    "num_cpus_per_task": 1
+                }
+            )
+
+            search = CBO(problem, evaluator)
+
+            search.search()
+
+    Then replace the ``ssh`` call with:
+
+    .. code-block:: bash
+
+        ssh $HEAD_NODE_IP "source $INIT_SCRIPT; cd $EXP_DIR; \
+            python myscript.py"
+
+    This can be more practical to use this approach when integrating DeepHyper in a different workflow.
+
+
+.. _theta-1-evaluation-per-N-node:
+
+1-evaluation per N-node
+-----------------------
+
+.. important::
+
+    **Section under construction!**
+
+The Ray workers are launch on the head node this time. This will allow us to use MPI inside our run-function.
+
+.. code-block:: bash
+    :caption: **file**: ``deephyper-job.qsub``
+
+    #!/bin/bash
+    #COBALT -A datascience
+    #COBALT -n 2
+    #COBALT -q debug-flat-quad
+    #COBALT -t 30
+
+    # Initialize the head node
+    EXP_DIR=$PWD
+    INIT_SCRIPT=$PWD/SetUpEnv.sh
+    source $INIT_SCRIPT
+
+    # Start Ray workers on the head node
+    for port in $(seq 6379 9000); do
+        RAY_PORT=$port;
+        ray start --head --num-cpus 2 --port $RAY_PORT;
+        if [ $? -eq 0 ]; then
+            break
+        fi
+    done
+
+    # Execute the DeepHyper Task
+    python myscript.py
+
+In this case the ``run`` function can call MPI routines:
+
+.. code-block:: python
+
+    import os
+
+    def run(config):
+
+        os.system("aprun -n .. -N ..")
+
+        return parse_result()
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -226,6 +226,12 @@ Table of Contents
     Publications <https://deephyper.github.io/papers>
     Authors <https://deephyper.github.io/aboutus>
 
+.. toctree:: 2
+   :caption: Facility Guides
+   :maxdepth: 1
+   :titlesonly:
+
+   facility/alcf/index
 
 .. toctree::
     :caption: API Reference
@@ -248,8 +254,6 @@ Table of Contents
     developer_guides/contributing
     developer_guides/software_architecture
     
-
-
 Indices and tables
 ==================
 


### PR DESCRIPTION
In the current documentation, the Tutorials section contains a subsection for the Argonne LCF which is not useful for general users. So this pull request moves that section to a separate section called Facility Guides.