### PR TITLE
Remove CSV results file

### DIFF
--- a/src/deephyper/evaluator/_evaluator.py
+++ b/src/deephyper/evaluator/_evaluator.py
@@ -553,7 +553,15 @@ class Evaluator(abc.ABC):
         return job
 
     def dump_job_results(self, *, log_dir: str, filename: str, csv_output: bool):
-        """here."""
+        """Dump completed jobs to a CSV file.
+
+        This will reset the ``Evaluator.jobs_done`` attribute to an empty list.
+
+        Args:
+            log_dir: Directory where to dump the CSV file.
+            filename: Name of the file where to write the data.
+            csv_output: Write the results to a CSV file.
+        """
         logging.info("Dumping completed jobs to CSV...")
 
         if self._job_class is HPOJob:
@@ -564,8 +572,15 @@ class Evaluator(abc.ABC):
         logging.info("Dumping done")
 
     def _dump_hpo_results(self, log_dir: str, filename: str, csv_output: bool):
-        """here."""
+        """Internal method to dump completed jobs to a CSV file using HPO format.
 
+        This will reset the ``Evaluator.jobs_done`` attribute to an empty list.
+
+        Args:
+            log_dir: Directory where to dump the CSV file.
+            filename: Name of the file where to write the data.
+            csv_output: Write the results to a CSV file.
+        """
         for job in self.jobs_done:
             result = copy.deepcopy(job.args)
 
@@ -613,8 +628,15 @@ class Evaluator(abc.ABC):
         self.jobs_done = []
 
     def _dump_results(self, log_dir: str, filename: str, csv_output: bool):
-        """here."""
+        """Internal method to dump completed jobs to a CSV file using normal format.
 
+        This will reset the ``Evaluator.jobs_done`` attribute to an empty list.
+
+        Args:
+            log_dir: Directory where to dump the CSV file.
+            filename: Name of the file where to write the data.
+            csv_output: Write the results to a CSV file.
+        """
         for job in self.jobs_done:
             # Start with job.id
             result = {"job_id": int(job.id.split(".")[1])}

--- a/src/deephyper/hpo/_cbo.py
+++ b/src/deephyper/hpo/_cbo.py
@@ -301,6 +301,7 @@ class CBO(Search):
         log_dir: str = ".",
         verbose: int = 0,
         stopper: Optional[Stopper] = None,
+        csv_output: bool = True,
         surrogate_model="ET",
         surrogate_model_kwargs: Optional[SurrogateModelKwargs] = None,
         acq_func: str = "UCBd",
@@ -315,9 +316,8 @@ class CBO(Search):
         moo_scalarization_strategy: str = "Chebyshev",
         moo_scalarization_weight=None,
         objective_scaler="minmax",
-        **kwargs,
     ):
-        super().__init__(problem, evaluator, random_state, log_dir, verbose, stopper)
+        super().__init__(problem, evaluator, random_state, log_dir, verbose, stopper, csv_output)
         # get the __init__ parameters
         self._init_params = locals()
 

--- a/src/deephyper/hpo/_cbo.py
+++ b/src/deephyper/hpo/_cbo.py
@@ -315,6 +315,7 @@ class CBO(Search):
         moo_scalarization_strategy: str = "Chebyshev",
         moo_scalarization_weight=None,
         objective_scaler="minmax",
+        **kwargs,
     ):
         super().__init__(problem, evaluator, random_state, log_dir, verbose, stopper)
         # get the __init__ parameters

--- a/src/deephyper/hpo/_cbo.py
+++ b/src/deephyper/hpo/_cbo.py
@@ -603,11 +603,11 @@ class CBO(Search):
             self._opt.tell(opt_X, opt_y)
             logging.info(f"Fitting took {time.time() - t1:.4f} sec.")
 
-    def _search(self, max_evals, timeout, max_evals_strict=False):
+    def _search(self, max_evals, max_evals_strict=False):
         if self._opt is None:
             self._setup_optimizer()
 
-        super()._search(max_evals, timeout, max_evals_strict)
+        super()._search(max_evals, max_evals_strict)
 
     def _get_surrogate_model(
         self,

--- a/src/deephyper/hpo/_cbo.py
+++ b/src/deephyper/hpo/_cbo.py
@@ -301,7 +301,6 @@ class CBO(Search):
         log_dir: str = ".",
         verbose: int = 0,
         stopper: Optional[Stopper] = None,
-        csv_output: bool = True,
         surrogate_model="ET",
         surrogate_model_kwargs: Optional[SurrogateModelKwargs] = None,
         acq_func: str = "UCBd",
@@ -317,7 +316,7 @@ class CBO(Search):
         moo_scalarization_weight=None,
         objective_scaler="minmax",
     ):
-        super().__init__(problem, evaluator, random_state, log_dir, verbose, stopper, csv_output)
+        super().__init__(problem, evaluator, random_state, log_dir, verbose, stopper)
         # get the __init__ parameters
         self._init_params = locals()
 

--- a/src/deephyper/hpo/_search.py
+++ b/src/deephyper/hpo/_search.py
@@ -51,15 +51,22 @@ class Search(abc.ABC):
     """Abstract class which represents a search algorithm.
 
     Args:
-        problem: object describing the search/optimization problem.
-        evaluator: object describing the evaluation process.
-        random_state (np.random.RandomState, optional): Initial random state of the search.
-            Defaults to ``None``.
-        log_dir (str, optional): Path to the directoy where results of the search are stored.
-            Defaults to ``"."``.
-        verbose (int, optional): Use verbose mode. Defaults to ``0``.
-        stopper (Stopper, optional): a stopper to leverage multi-fidelity when evaluating the
-            function. Defaults to ``None`` which does not use any stopper.
+        problem:
+            An object describing the search/optimization problem.
+        evaluator:
+            An object describing the evaluation process.
+        random_state (np.random.RandomState, optional):
+            Initial random state of the search. Defaults to ``None``.
+        log_dir (str, optional):
+            Path to the directoy where results of the search are stored. Defaults to ``"."``.
+        verbose (int, optional):
+            Use verbose mode. Defaults to ``0``.
+        stopper (Stopper, optional):
+            A stopper to leverage multi-fidelity when evaluating the function. Defaults to ``None``
+            which does not use any stopper.
+        csv_output (bool, optional):
+            Results are written to CSV file when ``True`` otherwise don't write to file when
+            ``False``. Default value is ``True``.
     """
 
     def __init__(
@@ -70,6 +77,7 @@ class Search(abc.ABC):
         log_dir=".",
         verbose=0,
         stopper=None,
+        csv_output: bool = True,
     ):
         # TODO: stopper should be an argument passed here... check CBO and generalize
         # get the __init__ parameters
@@ -126,6 +134,7 @@ class Search(abc.ABC):
         self._evaluator._stopper = stopper
 
         self.stopped = False
+        self.csv_output = csv_output
 
     def check_evaluator(self, evaluator):
         if not (isinstance(evaluator, Evaluator)):
@@ -418,6 +427,5 @@ class Search(abc.ABC):
         Args:
             flush (bool, optional): Force the dumping if set to ``True``. Defaults to ``False``.
         """
-        if self.is_master:
-            print("HERE")
+        if self.is_master and self.csv_output:
             self._evaluator.dump_jobs_done_to_csv(log_dir=self._log_dir, flush=flush)

--- a/src/deephyper/hpo/_search.py
+++ b/src/deephyper/hpo/_search.py
@@ -1,7 +1,6 @@
 import abc
 import asyncio
 import copy
-import csv
 import json
 import logging
 import os
@@ -218,7 +217,7 @@ class Search(abc.ABC):
             - ``m:METADATA_NAME``: for each metadata of the problem. Some metadata are always
                 present like ``m:timestamp_submit`` and ``m:timestamp_gather`` which are the
                 timestamps of the submission and gathering of the job.
-    """
+        """
         self.stopped = False
         self.csv_output = csv_output
 

--- a/src/deephyper/hpo/_search.py
+++ b/src/deephyper/hpo/_search.py
@@ -229,7 +229,7 @@ class Search(abc.ABC):
         try:
             if np.isscalar(timeout) and timeout > 0:
                 self._evaluator.timeout = timeout
-            self._search(max_evals, timeout, max_evals_strict)
+            self._search(max_evals, max_evals_strict)
         except MaximumJobsSpawnReached:
             self.stopped = True
             logging.warning(
@@ -419,4 +419,5 @@ class Search(abc.ABC):
             flush (bool, optional): Force the dumping if set to ``True``. Defaults to ``False``.
         """
         if self.is_master:
+            print("HERE")
             self._evaluator.dump_jobs_done_to_csv(log_dir=self._log_dir, flush=flush)

--- a/src/deephyper/hpo/_search.py
+++ b/src/deephyper/hpo/_search.py
@@ -70,7 +70,6 @@ class Search(abc.ABC):
         log_dir=".",
         verbose=0,
         stopper=None,
-        **kwargs,
     ):
         # TODO: stopper should be an argument passed here... check CBO and generalize
         # get the __init__ parameters
@@ -293,14 +292,12 @@ class Search(abc.ABC):
                 df.loc[mask_no_failures, "pareto_efficient"] = mask_pareto_front
                 df.to_csv(df_path, index=False)
 
-    def _search(self, max_evals, timeout, max_evals_strict=False):
+    def _search(self, max_evals, max_evals_strict=False):
         """Search algorithm logic.
 
         Args:
             max_evals (int): The maximum number of evaluations of the run function to perform
                 before stopping the search. Defaults to -1, will run indefinitely.
-            timeout (int): The time budget of the search before stopping. Defaults to ``None``,
-                will not impose a time budget.
             max_evals_strict (bool, optional): Wether the number of submitted jobs should be
             strictly equal to ``max_evals``.
         """

--- a/src/deephyper/hpo/_search.py
+++ b/src/deephyper/hpo/_search.py
@@ -197,11 +197,28 @@ class Search(abc.ABC):
         """Execute the search algorithm.
 
         Args:
-            max_evals: here
+            max_evals: The max number of evaluations for the run function to perform before
+                stopping the search. Defaults to -1 to run indefinitely.
+            timeout: The time budget (in seconds) of the search before stopping. Defaults to
+                ``None`` to not impose a time budget.
+            max_evals_strict: If ``True`` the search will not spawn more than ``max_evals`` jobs.
+                Defaults to ``False``.
+            csv_output: Write the results to a CSV file. Default is True.
 
         Returns:
-            here
-        """
+            A Pandas DataFrame containing the evaluations performed or None if the search could not
+            evaluate any configuration.
+
+            The DataFrame contains the following columns:
+            - ``p:HYPERPARAMETER_NAME``: for each hyperparameter of the problem.
+            - ``objective``: for single objective optimization.
+            - ``objective_0``, ``objective_1``, ...: for multi-objective optimization.
+            - ``job_id``: the identifier of the job.
+            - ``job_status``: the status of the job at the end of the search.
+            - ``m:METADATA_NAME``: for each metadata of the problem. Some metadata are always
+                present like ``m:timestamp_submit`` and ``m:timestamp_gather`` which are the
+                timestamps of the submission and gathering of the job.
+    """
         self.stopped = False
         self.csv_output = csv_output
 
@@ -404,13 +421,8 @@ class Search(abc.ABC):
         """
 
     def dump_results(self):
-        """Dump jobs completed to CSV in log_dir.
-
-        Args:
-            flush (bool, optional): Force the dumping if set to ``True``. Defaults to ``False``.
-        """
+        """Dump job results using the evaluator."""
         if self.is_master:
-            # self._evaluator.dump_jobs_done_to_csv(log_dir=self._log_dir, flush=flush)
             self._evaluator.dump_job_results(
                 log_dir=self._log_dir, filename="results.csv", csv_output=self.csv_output
             )

--- a/tests/evaluator/test__evaluator.py
+++ b/tests/evaluator/test__evaluator.py
@@ -67,7 +67,7 @@ def test_run_function_standards(tmp_path):
 
     evaluator.submit(configs)
     evaluator.gather(type="ALL")
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     results = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert all(
         results.columns
@@ -95,7 +95,7 @@ def test_run_function_standards(tmp_path):
     evaluator._job_class = HPOJob
     evaluator.submit(configs)
     evaluator.gather(type="ALL")
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     results = pd.read_csv(os.path.join(tmp_path, "results.csv")).sort_values(by="job_id")
     assert all(
         results.columns
@@ -120,7 +120,7 @@ def test_run_function_standards(tmp_path):
     evaluator._job_class = HPOJob
     evaluator.submit(configs)
     evaluator.gather(type="ALL")
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     results = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert all(
         results.columns
@@ -148,7 +148,7 @@ def test_run_function_standards(tmp_path):
     evaluator._job_class = HPOJob
     evaluator.submit(configs)
     evaluator.gather(type="ALL")
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     results = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert list(sorted(results.columns)) == list(
         sorted(
@@ -181,7 +181,7 @@ def test_run_function_standards(tmp_path):
     evaluator._job_class = HPOJob
     evaluator.submit(configs)
     evaluator.gather(type="ALL")
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     results = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert list(sorted(results.columns)) == list(
         sorted(
@@ -216,7 +216,7 @@ def test_run_function_standards(tmp_path):
     evaluator._job_class = HPOJob
     evaluator.submit(configs)
     evaluator.gather(type="ALL")
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     results = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert list(sorted(results.columns)) == list(
         sorted(
@@ -255,7 +255,7 @@ def test_run_function_standards(tmp_path):
     evaluator._job_class = HPOJob
     evaluator.submit(configs)
     evaluator.gather(type="ALL")
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     results = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert list(sorted(results.columns)) == list(
         sorted(
@@ -292,7 +292,7 @@ def test_run_function_standards(tmp_path):
     evaluator.num_objective = 2
     evaluator.submit(configs)
     evaluator.gather(type="ALL")
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     results = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert list(sorted(results.columns)) == list(
         sorted(
@@ -346,7 +346,7 @@ def execute_evaluator(method, tmp_path):
     assert len(jobs) == 1
     evaluator.close()
 
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     result = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert len(result) == 20
     assert all(s == "CANCELLED" for s in result["job_status"].iloc[-9:])
@@ -448,7 +448,7 @@ def test_evaluator_with_Job(tmp_path):
     jobs_done = evaluator.gather("ALL")
     for jobi in jobs_done:
         assert jobi.output == 0
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     df = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert len(df) == 10
     assert len(df.columns) == 6
@@ -461,7 +461,7 @@ def test_evaluator_with_Job(tmp_path):
     jobs_done = evaluator.gather("ALL")
     for jobi in jobs_done:
         assert isinstance(jobi.output, dict)
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     df = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert len(df) == 10
     assert len(df.columns) == 10
@@ -476,7 +476,7 @@ def test_evaluator_with_Job(tmp_path):
         assert jobi.output == 0
         assert "timestamp_start" in jobi.metadata
         assert "timestamp_end" in jobi.metadata
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     df = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert len(df) == 10
     assert len(df.columns) == 8
@@ -493,7 +493,7 @@ def test_evaluator_with_Job(tmp_path):
         assert jobi.output["y2"] == jobi.args["x2"]
         assert "timestamp_start" in jobi.metadata
         assert "timestamp_end" in jobi.metadata
-    evaluator.dump_jobs_done_to_csv(log_dir=tmp_path)
+    evaluator.dump_job_results(log_dir=tmp_path, filename="results.csv", csv_output=True)
     df = pd.read_csv(os.path.join(tmp_path, "results.csv"))
     assert len(df) == 10
     assert len(df.columns) == 12


### PR DESCRIPTION
This adds a `remove_csv` argument at `Search.search(..., remove_csv=True)` to provide an option for users to automatically remove the CSV results file after it is created. The default value is `False` to keep the original behavior of the code. Resolves issue #309. 